### PR TITLE
Fix offline cap handling and add persistence tests

### DIFF
--- a/memory/activeContext.md
+++ b/memory/activeContext.md
@@ -2,13 +2,12 @@
 
 ## Current Focus
 
-Core MVP delivered; preparing documentation and PR handoff.
+Finish persistence/offline iteration by fixing cap handling and hardening tests per full spec.
 
 ## Recent Changes
 
-- Implemented store, ECS systems, rendering components, UI overlay, and automated tests.
-- Verified linting, formatting, type checking, unit, and e2e suites.
+- Core MVP delivered with ECS loop, rendering, and UI panel.
 
 ## Next Steps
 
-- Summarize work, capture evidence, and open PR.
+- Execute iteration plan in TASK002 to finalize persistence/offline work and confirm testing suite.

--- a/memory/progress.md
+++ b/memory/progress.md
@@ -2,8 +2,9 @@
 
 ## Summary
 
-Core MVP implemented with store, ECS loop, rendering, UI, and tests.
+- Core MVP implemented with store, ECS loop, rendering, UI, and tests.
+- Persistence/offline iteration underway; offline cap bug fix and regression tests in progress.
 
 ## Open Items
 
-- Prepare PR summary and documentation artifacts.
+- Prepare PR summary and documentation artifacts once persistence iteration is finalized.

--- a/memory/tasks/TASK002-persistence-offline.md
+++ b/memory/tasks/TASK002-persistence-offline.md
@@ -1,0 +1,34 @@
+# TASK002 — Persistence, Offline Catch-Up, and Settings
+
+## Status
+
+In Progress
+
+## Summary
+
+Implement save/load with autosave and offline simulation, create settings UI for controls, and flesh out refinery system per spec.
+
+## Tasks
+
+1. Extend Zustand store with settings slice, serialization helpers, and import/export actions.
+2. Implement persistence manager module handling load, save, offline simulation, and autosave timers; integrate at bootstrap.
+3. Build settings panel UI with autosave toggle/interval, offline cap, import/export controls, and error feedback.
+4. Move ore→bars conversion into dedicated refinery system and adjust tick usage.
+5. Update offline helper utilities and write Vitest specs for offline simulation parity and refinery throughput.
+6. Add tests for persistence serialization and settings UI interactions; expand Playwright e2e to cover import/export smoke.
+7. Run lint, type check, unit, and e2e tests; update documentation/memory on completion.
+
+## Dependencies
+
+- Requires design DES002.
+
+## Acceptance
+
+- Requirements RQ-006, RQ-007, and RQ-008 satisfied with passing automated tests.
+
+## Current Iteration Plan (2025-02-14)
+
+1. Fix offline simulation clamping so the user-configured offline cap is honored instead of falling back to the default value.
+2. Update the persistence manager to forward the configured cap and adjust helper signatures accordingly.
+3. Add regression tests covering custom offline caps and persistence load behavior (with mocked storage/time).
+4. Re-run formatters, linters, type checking, unit tests, and e2e suite to validate the changes.

--- a/src/lib/offline.test.ts
+++ b/src/lib/offline.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { createStoreInstance } from '@/state/store';
+import { clampOfflineSeconds, simulateOfflineProgress } from '@/lib/offline';
+
+const cloneStore = () => {
+  const store = createStoreInstance();
+  const state = store.getState();
+  store.setState({
+    resources: { ...state.resources, ore: 200, bars: 0 },
+    modules: { ...state.modules, refinery: 2 },
+    prestige: { ...state.prestige, cores: 4 },
+  });
+  return store;
+};
+
+describe('lib/offline', () => {
+  it('matches manual refinement loop', () => {
+    const offlineStore = cloneStore();
+    const manualStore = cloneStore();
+    simulateOfflineProgress(offlineStore, 6, { step: 0.2 });
+    const manualStep = 0.2;
+    const iterations = Math.floor(6 / manualStep);
+    const remainder = 6 - iterations * manualStep;
+    for (let i = 0; i < iterations; i += 1) {
+      manualStore.getState().processRefinery(manualStep);
+    }
+    if (remainder > 0) {
+      manualStore.getState().processRefinery(remainder);
+    }
+    const offlineResources = offlineStore.getState().resources;
+    const manualResources = manualStore.getState().resources;
+    expect(offlineResources.bars).toBeCloseTo(manualResources.bars, 5);
+    expect(offlineResources.ore).toBeCloseTo(manualResources.ore, 5);
+  });
+
+  it('honors provided offline cap hours', () => {
+    const baseStore = createStoreInstance();
+    const state = baseStore.getState();
+    const update = {
+      resources: { ...state.resources, ore: 10_000, bars: 0 },
+      modules: { ...state.modules, refinery: 3 },
+      prestige: { ...state.prestige, cores: 6 },
+    };
+    baseStore.setState(update);
+    const manualStore = createStoreInstance();
+    manualStore.setState(update);
+
+    const seconds = 10 * 3600; // 10 hours
+    const capHours = 12;
+    const step = 600; // 10 minutes per step
+    simulateOfflineProgress(baseStore, seconds, { step, capHours });
+
+    const clamped = clampOfflineSeconds(seconds, capHours);
+    const iterations = Math.floor(clamped / step);
+    const remainder = clamped - iterations * step;
+    for (let i = 0; i < iterations; i += 1) {
+      manualStore.getState().processRefinery(step);
+    }
+    if (remainder > 0) {
+      manualStore.getState().processRefinery(remainder);
+    }
+
+    const offline = baseStore.getState().resources;
+    const manual = manualStore.getState().resources;
+    expect(offline.bars).toBeCloseTo(manual.bars, 5);
+    expect(offline.ore).toBeCloseTo(manual.ore, 5);
+  });
+});

--- a/src/lib/offline.ts
+++ b/src/lib/offline.ts
@@ -11,17 +11,37 @@ export const computeOfflineSeconds = (lastSave: number, now: number, capHours = 
   return clampOfflineSeconds(ms / 1000, capHours);
 };
 
-export const simulateOfflineProgress = (store: StoreApi<StoreState>, seconds: number) => {
-  const clamped = clampOfflineSeconds(seconds);
-  if (clamped <= 0) return;
-  const step = 0.1;
-  const iterations = Math.floor(clamped / step);
-  const remainder = clamped - iterations * step;
-  const api = store.getState();
+export interface OfflineSimulationOptions {
+  step?: number;
+  capHours?: number;
+}
+
+export const simulateOfflineProgress = (
+  store: StoreApi<StoreState>,
+  seconds: number,
+  options?: OfflineSimulationOptions,
+) => {
+  const step = options?.step && options.step > 0 ? options.step : 0.1;
+  const normalizedSeconds = Math.max(0, seconds);
+  const clampedSeconds =
+    options?.capHours === undefined
+      ? normalizedSeconds
+      : clampOfflineSeconds(normalizedSeconds, options.capHours);
+  if (clampedSeconds <= 0) return;
+  const iterations = Math.floor(clampedSeconds / step);
+  const remainder = clampedSeconds - iterations * step;
+  const runStep = (delta: number) => {
+    const api = store.getState();
+    if (typeof api.processRefinery === 'function') {
+      api.processRefinery(delta);
+    } else {
+      api.tick(delta);
+    }
+  };
   for (let i = 0; i < iterations; i += 1) {
-    api.tick(step);
+    runStep(step);
   }
   if (remainder > 0) {
-    api.tick(remainder);
+    runStep(remainder);
   }
 };

--- a/src/state/persistence.test.ts
+++ b/src/state/persistence.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { createStoreInstance } from '@/state/store';
+import { createPersistenceManager, SAVE_KEY } from '@/state/persistence';
+import * as offlineLib from '@/lib/offline';
+
+const FIXED_NOW = new Date('2025-02-14T12:00:00Z');
+
+describe('state/persistence', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('loads save and simulates offline with configured cap hours', () => {
+    const store = createStoreInstance();
+    const snapshot = {
+      resources: { ore: 5_000, bars: 0, energy: 160, credits: 0 },
+      modules: { droneBay: 3, refinery: 2, storage: 1, solar: 1, scanner: 0 },
+      prestige: { cores: 4 },
+      save: { lastSave: FIXED_NOW.getTime() - 13 * 3600 * 1000, version: '0.1.0' },
+      settings: {
+        autosaveEnabled: true,
+        autosaveInterval: 10,
+        offlineCapHours: 12,
+        notation: 'standard' as const,
+      },
+      rngSeed: 123456789,
+    };
+    window.localStorage.setItem(SAVE_KEY, JSON.stringify(snapshot));
+
+    const spy = vi.spyOn(offlineLib, 'simulateOfflineProgress');
+
+    const manager = createPersistenceManager(store);
+    manager.load();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [api, seconds, options] = spy.mock.calls[0];
+    expect(api).toBe(store);
+    expect(seconds).toBeCloseTo(12 * 3600, 5);
+    expect(options?.capHours).toBe(12);
+
+    const state = store.getState();
+    expect(state.resources.bars).toBeGreaterThan(0);
+    expect(state.save.lastSave).toBeGreaterThanOrEqual(Date.now());
+
+    const persisted = window.localStorage.getItem(SAVE_KEY);
+    expect(persisted).toBeTruthy();
+  });
+});

--- a/src/state/persistence.ts
+++ b/src/state/persistence.ts
@@ -1,0 +1,129 @@
+import type { StoreApi } from 'zustand';
+import {
+  type StoreState,
+  type StoreSnapshot,
+  type StoreSettings,
+  serializeStore,
+  stringifySnapshot,
+  parseSnapshot,
+  storeApi,
+  saveVersion,
+} from '@/state/store';
+import { computeOfflineSeconds, simulateOfflineProgress } from '@/lib/offline';
+
+export const SAVE_KEY = 'space-factory-save';
+
+export interface PersistenceManager {
+  load(): void;
+  start(): void;
+  stop(): void;
+  saveNow(): void;
+  exportState(): string;
+  importState(payload: string): boolean;
+}
+
+const hasStorage = () => typeof window !== 'undefined' && !!window.localStorage;
+
+const equality = (a: StoreSettings, b: StoreSettings) =>
+  a.autosaveEnabled === b.autosaveEnabled && a.autosaveInterval === b.autosaveInterval;
+
+export const createPersistenceManager = (
+  store: StoreApi<StoreState> = storeApi,
+): PersistenceManager => {
+  let autosaveHandle: ReturnType<typeof setInterval> | null = null;
+  let unsubscribe: (() => void) | null = null;
+
+  const clearAutosave = () => {
+    if (autosaveHandle) {
+      clearInterval(autosaveHandle);
+      autosaveHandle = null;
+    }
+  };
+
+  const persistSnapshot = (snapshot: StoreSnapshot) => {
+    if (!hasStorage()) return;
+    try {
+      window.localStorage.setItem(SAVE_KEY, stringifySnapshot(snapshot));
+    } catch (error) {
+      console.warn('Failed to persist save', error);
+    }
+  };
+
+  const saveNow = () => {
+    if (!hasStorage()) return;
+    const now = Date.now();
+    store.getState().setLastSave(now);
+    const snapshot = serializeStore(store.getState());
+    snapshot.save.lastSave = now;
+    snapshot.save.version ??= saveVersion;
+    persistSnapshot(snapshot);
+  };
+
+  const scheduleAutosave = (settings: StoreSettings = store.getState().settings) => {
+    clearAutosave();
+    if (!settings.autosaveEnabled || !hasStorage()) return;
+    const delay = Math.max(1, Math.floor(settings.autosaveInterval)) * 1000;
+    autosaveHandle = setInterval(() => {
+      saveNow();
+    }, delay);
+  };
+
+  const load = () => {
+    if (!hasStorage()) return;
+    const raw = window.localStorage.getItem(SAVE_KEY);
+    if (!raw) {
+      store.getState().setLastSave(Date.now());
+      return;
+    }
+    const snapshot = parseSnapshot(raw);
+    if (!snapshot) {
+      store.getState().setLastSave(Date.now());
+      return;
+    }
+    store.getState().applySnapshot(snapshot);
+    const now = Date.now();
+    const settings = store.getState().settings;
+    const offlineSeconds = computeOfflineSeconds(
+      snapshot.save.lastSave,
+      now,
+      settings.offlineCapHours,
+    );
+    if (offlineSeconds > 0) {
+      simulateOfflineProgress(store, offlineSeconds, {
+        capHours: settings.offlineCapHours,
+      });
+    }
+    store.getState().setLastSave(now);
+    saveNow();
+  };
+
+  const start = () => {
+    scheduleAutosave();
+    unsubscribe ??= store.subscribe((state, previous) => {
+      if (!previous || !equality(state.settings, previous.settings)) {
+        scheduleAutosave(state.settings);
+      }
+    });
+  };
+
+  const stop = () => {
+    clearAutosave();
+    if (unsubscribe) {
+      unsubscribe();
+      unsubscribe = null;
+    }
+  };
+
+  const exportState = () => store.getState().exportState();
+
+  const importState = (payload: string) => {
+    const success = store.getState().importState(payload);
+    if (!success) return false;
+    store.getState().setLastSave(Date.now());
+    saveNow();
+    scheduleAutosave();
+    return true;
+  };
+
+  return { load, start, stop, saveNow, exportState, importState };
+};


### PR DESCRIPTION
## Summary
- allow offline simulation to honor the user-configured cap by parameterizing the helper and forwarding settings from the persistence manager
- add regression tests covering the offline simulator and persistence load path, and document the current iteration plan in the memory bank

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm test -- --run
- npm run e2e *(fails: browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68f02d811470832abb889fb47c6e845f