### PR TITLE
Align offline simulation with store refinery processing

### DIFF
--- a/memory/activeContext.md
+++ b/memory/activeContext.md
@@ -2,16 +2,18 @@
 
 ## Current Focus
 
-Stabilize Milestone 2 by aligning offline catch-up with the shared refinery helpers before pivoting to energy throttling design work.
+Advance TASK002 by unifying refinery processing between live ECS ticks and offline catch-up while capturing telemetry for later balancing work.
 
 ## Recent Changes
 
-- Added shared refinery math utilities plus `runRefineryStep` so ECS and offline flows reuse one implementation.
-- Wired a dedicated refinery system into the render loop and removed the redundant `store.tick` invocation.
-- Refactored offline simulation to iterate against snapshot data using the shared refinery math while preserving untouched resource fields.
+- Ensured the refinery ECS system now delegates directly to the store's `processRefinery` method for identical live/offline behavior.
+- Refactored offline simulation to call store actions in fixed steps and return telemetry about ore consumption and bar production.
+- Added persistence logging for offline catch-up runs to aid balancing and regression debugging.
+- Expanded the implementation plan with an error handling matrix and unit testing roadmap to guide upcoming milestones.
 
 ## Next Steps
 
-- Observe autosave/offline behavior with the new ECS delegation and capture any balance regressions.
+- Monitor telemetry from offline recap sessions to ensure refinery parity holds under varied saves.
 - Outline follow-up work for energy throttling and per-drone batteries once refinery parity remains stable.
 - Capture any manual QA findings from extended offline catch-up runs and feed them into the upcoming energy milestone planning.
+- Feed the new error handling/test strategy into Milestone 1 execution notes and update task breakdowns accordingly.

--- a/memory/progress.md
+++ b/memory/progress.md
@@ -8,6 +8,8 @@
 - Added requirement status table flagging the persistence manager store gaps and differentiating implemented vs. planned systems.
 - Kicked off Milestone 2 by migrating refinery processing into an ECS system with shared helpers and new parity unit tests.
 - Finalized offline catch-up alignment by iterating on snapshot data and adding regression coverage for untouched resources.
+- Expanded the implementation roadmap with error handling and testing strategy sections to de-risk upcoming persistence and ECS work.
+- Refined offline catch-up to reuse the store's refinery logic directly, emit telemetry for ore/bars processed, and surface load-time summaries via persistence logging.
 
 ## Open Items
 

--- a/memory/tasks/TASK002-persistence-offline.md
+++ b/memory/tasks/TASK002-persistence-offline.md
@@ -54,6 +54,12 @@ Implement save/load with autosave and offline simulation, create settings UI for
 - Added a regression test ensuring untouched resource fields (energy, credits) remain stable after offline processing.
 - Ran the formatter, ESLint, type checking, and unit suites to validate the refinery alignment changes.
 
+### 2025-02-19
+
+- Updated the refinery ECS system to invoke the store's `processRefinery` action so live ticks and offline loops share the same execution path.
+- Refactored offline simulation to drive `processRefinery` directly, returning a telemetry report for ore consumption and bar output.
+- Logged offline recap summaries during persistence load to aid balancing and regression triage, with refreshed Vitest coverage for the new report contract.
+
 ## Updated Iteration Plan (2025-02-18)
 
 1. Evaluate whether offline recap UX or telemetry should surface refinery throughput insights for players.

--- a/plan/implementation-plan.md
+++ b/plan/implementation-plan.md
@@ -358,6 +358,40 @@ Recommended execution order: M1 → M2 → M3 → M4 → M5 → M6 → M7, with 
 
 ---
 
+## Error handling matrix
+
+| Scenario | Detection | Automatic handling | Player feedback | Telemetry/logging |
+| --- | --- | --- | --- | --- |
+| **Autosave failure (quota, storage unavailable)** | Wrap `localStorage.setItem` in try/catch and track error count per session. | Pause autosave loop, retry once after 5 seconds, and queue manual save prompt. | Surface toast/banner explaining that autosave paused with link to export manually. | Log structured warning with error message, quota bytes, and throttled repetition guard.
+| **Import payload invalid (schema mismatch, JSON parse)** | Validate JSON via Zod schema before applying snapshot. | Abort import, keep previous state untouched, and clear pending file reference. | Modal error with actionable text (“JSON malformed” vs. “Fields missing: …”) and docs link. | Emit analytics event containing validation errors (redacted of payload) for debugging trends.
+| **Migration version gap** | Compare payload `version` against supported map. | Route through migration pipeline, populating defaults for new fields; if unrecoverable, fallback to backup snapshot. | Show summary dialog enumerating applied migrations or failure message instructing to update game. | Record migration results and durations; tag unrecoverable migrations for alerting.
+| **Offline simulation exceeds cap** | Calculate elapsed hours on load; compare to `settings.offlineCapHours`. | Clamp simulated hours to cap and store truncated delta for analytics. | Display recap banner noting cap applied to avoid unexpected jumps. | Log info with elapsed vs. capped hours for balancing reviews.
+| **Persistence load missing key/corrupted** | Guard `localStorage.getItem` response and JSON parse inside try/catch. | Revert to fresh default store while stashing corrupt payload in `localStorage` backup key. | Notify via startup dialog that save could not be loaded and where backup stored. | Log error including stack trace and backup key reference; increment metric for failed loads.
+| **Settings UI interaction errors (invalid input, throttling conflicts)** | Form-level validation with controlled components and Zustand actions returning status. | Reject state update, reset field to last valid value, and focus problematic input. | Inline validation message plus tooltip explaining acceptable range/format. | Track validation error type and frequency for UX follow-up.
+
+---
+
+## Unit testing strategy
+
+- **Core principles**
+  - Favor deterministic simulations with seeded RNG to avoid flaky assertions.
+  - Collocate Vitest suites beside implementation files (`*.test.ts`) to ensure quick discovery.
+  - Mirror offline vs. live execution paths in paired tests to guarantee parity.
+- **Milestone mapping**
+  - **M1 (Persistence & Settings)** — Unit tests for store serialization, persistence timing, and Settings form reducers; Playwright smoke for import/export UX and autosave banner.
+  - **M2 (Refinery ECS)** — Focused unit tests validating ore→bar conversion, ECS update ordering, and offline parity harness using shared fixtures.
+  - **M3 (Energy throttling)** — Simulation tests covering battery drain/charge curves, throttle boundaries, and deterministic AI pathing with seeded inputs.
+  - **M4 (Seeded RNG)** — Pure function tests for RNG outputs and integration snapshot ensuring identical world state given same seed.
+  - **M5 (Visual polish)** — Lightweight rendering tests verifying Settings toggles wire up correctly; optional screenshot regression tests for trails/highlights.
+  - **M6 (CI)** — Meta-tests verifying coverage thresholds and Playwright reliability (retries, artifact generation) within pipeline.
+  - **M7 (Migration & Docs)** — Regression tests expanding persistence suites with legacy payload fixtures and doc linting (markdown, links) if feasible.
+- **Tooling**
+  - Use Vitest with jsdom environment for UI/unit tests, `@testing-library/react` for interaction fidelity, and Playwright for cross-browser scenarios.
+  - Integrate coverage reporting (`vitest --coverage`) into CI gating; set thresholds once baseline established.
+  - Employ synthetic clocks (`vi.useFakeTimers`) in persistence tests to accelerate autosave/offline scenarios without real delays.
+
+---
+
 ## Next actions
 
 1. Confirm Memory Bank entries for persistence work (create/update task in `memory/tasks`).

--- a/src/ecs/systems/refinery.test.ts
+++ b/src/ecs/systems/refinery.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createGameWorld } from '@/ecs/world';
 import { createRefinerySystem } from '@/ecs/systems/refinery';
-import { createStoreInstance, runRefineryStep } from '@/state/store';
+import { createStoreInstance } from '@/state/store';
 
 const setupStore = () => {
   const store = createStoreInstance();
@@ -22,7 +22,7 @@ describe('ecs/systems/refinery', () => {
     const system = createRefinerySystem(world, store);
     const dt = 0.75;
     system(dt);
-    runRefineryStep(mirrorStore, dt);
+    mirrorStore.getState().processRefinery(dt);
     const systemResources = store.getState().resources;
     const mirrorResources = mirrorStore.getState().resources;
     expect(systemResources.bars).toBeCloseTo(mirrorResources.bars, 5);

--- a/src/ecs/systems/refinery.ts
+++ b/src/ecs/systems/refinery.ts
@@ -1,6 +1,7 @@
 import type { GameWorld } from '@/ecs/world';
-import { runRefineryStep, type StoreApiType } from '@/state/store';
+import type { StoreApiType } from '@/state/store';
 
 export const createRefinerySystem = (_world: GameWorld, store: StoreApiType) => (dt: number) => {
-  runRefineryStep(store, dt);
+  if (dt <= 0) return;
+  store.getState().processRefinery(dt);
 };

--- a/src/state/persistence.ts
+++ b/src/state/persistence.ts
@@ -89,9 +89,15 @@ export const createPersistenceManager = (
       settings.offlineCapHours,
     );
     if (offlineSeconds > 0) {
-      simulateOfflineProgress(store, offlineSeconds, {
+      const report = simulateOfflineProgress(store, offlineSeconds, {
         capHours: settings.offlineCapHours,
       });
+      if (report.barsProduced > 0 || report.oreConsumed > 0) {
+        console.info(
+          `Simulated ${report.simulatedSeconds.toFixed(1)}s of offline progress`,
+          report,
+        );
+      }
     }
     store.getState().setLastSave(now);
     saveNow();

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -149,17 +149,6 @@ export const applyRefineryProduction = (state: StoreState, stats: RefineryStats)
   },
 });
 
-export const runRefineryStep = (store: StoreApiType, dt: number): RefineryStats => {
-  if (dt <= 0) return emptyRefineryStats;
-  const state = store.getState();
-  const stats = computeRefineryProduction(state, dt);
-  if (stats.oreConsumed <= 0 && stats.barsProduced <= 0) {
-    return emptyRefineryStats;
-  }
-  store.setState(applyRefineryProduction(state, stats));
-  return stats;
-};
-
 export const costForLevel = (base: number, level: number) =>
   Math.ceil(base * Math.pow(GROWTH, level));
 


### PR DESCRIPTION
## Summary
- have the refinery ECS system and offline simulator call the shared store `processRefinery` action and surface telemetry during persistence load
- return a structured report from `simulateOfflineProgress` while expanding unit coverage for parity, caps, and invariants
- refresh the memory bank active context, progress log, and TASK002 record with the new implementation work

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f09aadbe34832aa77d3184dc5a28bd