### PR TITLE
Implement per-drone energy throttle and seeded RNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Player progress is stored in `localStorage` using the `space-factory-save` key. 
 
 ## Energy throttling
 
-Energy production and consumption are evaluated every simulation tick. When the battery level falls, a throttle factor computed from `energy / capacity` (clamped by the Settings "Throttle floor") slows mining progress and proportionally reduces per-drone consumption. This keeps the factory responsive—operations smooth out instead of stopping entirely—and allows excess generation to recharge the grid. The behavior is covered by dedicated unit tests for both the mining and power systems.
+Each drone tracks its own battery and drains power while travelling or mining. The drain rate scales with the configured "Throttle floor": the lower the battery, the slower the drone moves and mines, but progress never drops below the floor unless the player explicitly sets it to zero. The power system converts the factory's stored energy and solar generation into per-drone charging whenever drones are docked, keeping energy values non-negative and smoothing out bursts of demand. Dedicated unit tests cover mining, travel, and power behaviour under drained and replenished batteries.
 
 ## Deterministic RNG seeds
 
-Each save stores a `rngSeed` value. Fresh games generate a seed using `crypto.getRandomValues` (falling back to `Math.random` if necessary). Exported saves include the seed, and importing that payload restores the same seed so asteroid layouts and other random-driven systems stay reproducible. Seeds that are missing from older snapshots are regenerated automatically.
+Each save stores a `rngSeed` value. Fresh games generate a seed using `crypto.getRandomValues` (falling back to `Math.random` if necessary). A Mulberry32-based utility feeds world generation and math helpers so asteroid placement and other random-driven systems are reproducible. Exported saves include the seed, and importing that payload restores the same layout. Seeds that are missing from older snapshots are regenerated automatically.
 
 ## Testing & quality checks
 

--- a/memory/activeContext.md
+++ b/memory/activeContext.md
@@ -2,18 +2,16 @@
 
 ## Current Focus
 
-Advance TASK002 by unifying refinery processing between live ECS ticks and offline catch-up while capturing telemetry for later balancing work.
+Stabilize the new per-drone energy systems and seeded RNG pipeline from TASK006/TASK007, and prepare UI follow-ups for battery HUD feedback.
 
 ## Recent Changes
 
-- Ensured the refinery ECS system now delegates directly to the store's `processRefinery` method for identical live/offline behavior.
-- Refactored offline simulation to call store actions in fixed steps and return telemetry about ore consumption and bar production.
-- Added persistence logging for offline catch-up runs to aid balancing and regression debugging.
-- Expanded the implementation plan with an error handling matrix and unit testing roadmap to guide upcoming milestones.
+- Introduced per-drone battery fields, travel/mining throttling, and charging allocation with new unit coverage.
+- Added deterministic RNG utility, updated world generation to consume seeded randomness, and expanded tests/README accordingly.
+- Maintained persistence hooks so RNG seeds and energy settings continue to roundtrip through snapshots.
 
 ## Next Steps
 
-- Monitor telemetry from offline recap sessions to ensure refinery parity holds under varied saves.
-- Outline follow-up work for energy throttling and per-drone batteries once refinery parity remains stable.
-- Capture any manual QA findings from extended offline catch-up runs and feed them into the upcoming energy milestone planning.
-- Feed the new error handling/test strategy into Milestone 1 execution notes and update task breakdowns accordingly.
+- Monitor simulation telemetry to validate long-run battery balance and identify UI indicators needed for individual drones.
+- Plan HUD work to surface average/low battery warnings and evaluate Settings copy for throttle floor guidance.
+- Review RNG integration with save import/export flows and scope any reset/regeneration hooks needed for world rebuilds.

--- a/memory/designs/DES005-energy-throttle.md
+++ b/memory/designs/DES005-energy-throttle.md
@@ -1,6 +1,6 @@
 # DES005 — Energy Throttle & Per-Drone Battery
 
-**Status:** Draft
+**Status:** Completed
 **Created:** 2025-10-16
 
 ## Summary

--- a/memory/designs/DES006-seeded-rng.md
+++ b/memory/designs/DES006-seeded-rng.md
@@ -1,6 +1,6 @@
 # DES006 — Seeded RNG
 
-**Status:** Draft
+**Status:** Completed
 **Created:** 2025-10-16
 
 ## Summary
@@ -9,7 +9,7 @@ Add a deterministic RNG utility and route all random-dependent operations throug
 
 ## API
 
-- `createRNG(seed: number)` -> `{ next(): number, nextInt(max): number }`
+- `createRng(seed: number)` -> `{ seed: number, next(): number, nextInt(min, max): number, nextRange(min, max): number }`
 
 ## Notes
 

--- a/memory/progress.md
+++ b/memory/progress.md
@@ -10,8 +10,10 @@
 - Finalized offline catch-up alignment by iterating on snapshot data and adding regression coverage for untouched resources.
 - Expanded the implementation roadmap with error handling and testing strategy sections to de-risk upcoming persistence and ECS work.
 - Refined offline catch-up to reuse the store's refinery logic directly, emit telemetry for ore/bars processed, and surface load-time summaries via persistence logging.
+- Delivered per-drone battery throttling, charging allocation, and regression tests covering mining, travel, and power systems.
+- Implemented seeded RNG utility and routed world generation/math helpers through the stored seed with deterministic unit coverage and README updates.
 
 ## Open Items
 
-- Prepare PR summary covering the refinery system migration and associated tests.
-- Scope upcoming energy throttling/per-drone battery design work contingent on refinery stability.
+- Track UI follow-up for surfacing per-drone battery levels and throttle warnings in the HUD.
+- Validate seeded RNG integration across save import/export flows and plan any reset tooling.

--- a/memory/requirements.md
+++ b/memory/requirements.md
@@ -27,3 +27,11 @@ WHEN maintainers consult the spec for save/offline behavior, THE SYSTEM SHALL de
 ## RQ-007 Spec Differentiates Implemented vs. Planned UI/Systems
 
 WHEN the spec covers UI and ECS systems, THE SYSTEM SHALL distinguish between features present in the codebase and roadmap items, so that readers can see current coverage and open gaps. [Acceptance: Spec explicitly labels implemented HUD/Upgrade panel, notes missing Settings/offline recap, and calls out placeholder systems.]
+
+## RQ-008 Per-Drone Energy Throttle
+
+WHEN a drone consumes more power than the grid can supply, THE SYSTEM SHALL slow that drone's travel and mining speed according to its battery charge fraction while never dropping below the configured throttle floor and without allowing negative battery values. [Acceptance: Unit tests exercise mining and travel ticks with depleted batteries to confirm throttled progress and non-negative charge.]
+
+## RQ-009 Seeded World Generation
+
+WHEN a new world is generated with a given RNG seed, THE SYSTEM SHALL place asteroids in identical positions and with the same attributes whenever that seed is reused, while different seeds yield different layouts. [Acceptance: Unit tests construct worlds with shared/different seeds and compare asteroid distributions.]

--- a/memory/tasks/TASK006-energy-throttle.md
+++ b/memory/tasks/TASK006-energy-throttle.md
@@ -1,6 +1,6 @@
 # TASK006 - Energy Throttle & Per-Drone Battery
 
-**Status:** In Progress  
+**Status:** Completed
 **Added:** 2025-10-16  
 **Updated:** 2025-10-16
 
@@ -22,12 +22,12 @@ Extend drone entity components and modify travel/mining systems to apply `energy
 
 ## Subtasks
 
-| ID | Description | Status | Updated | Notes |
-| --- | ----------- | ------ | ------- | ----- |
-| 6.1 | Drone component updates | Not Started | 2025-10-16 | `src/ecs/world.ts` DroneEntity does not include per-drone battery fields yet. |
-| 6.2 | Travel & mining adjustments | Partially Completed | 2025-02-14 | `src/ecs/systems/mining.ts` and `src/ecs/systems/travel.ts` use `computeEnergyThrottle` to scale mining and travel behavior where appropriate. |
-| 6.3 | Power charging allocation | Partially Completed | 2025-02-14 | `src/ecs/systems/power.ts` computes generation, consumption and applies throttle globally; per-drone allocation not implemented. |
-| 6.4 | Settings & HUD wiring | Partially Completed | 2025-02-16 | Settings UI exposes throttleFloor; HUD feedback for individual drone battery not present. |
+| ID  | Description                 | Status              | Updated    | Notes                                                                                                                 |
+| --- | --------------------------- | ------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------- |
+| 6.1 | Drone component updates     | Completed           | 2025-10-16 | Added battery, maxBattery, and charging flags to `DroneEntity` in `src/ecs/world.ts`.                                 |
+| 6.2 | Travel & mining adjustments | Completed           | 2025-10-16 | Both systems now scale movement/mining speed by per-drone energy fraction and drain battery via `consumeDroneEnergy`. |
+| 6.3 | Power charging allocation   | Completed           | 2025-10-16 | `src/ecs/systems/power.ts` allocates stored energy to docked drones, clamping values and toggling `charging` state.   |
+| 6.4 | Settings & HUD wiring       | Partially Completed | 2025-10-16 | Settings UI exposes throttleFloor; HUD feedback for individual drone battery not present.                             |
 
 ## Acceptance Criteria
 
@@ -39,3 +39,9 @@ Extend drone entity components and modify travel/mining systems to apply `energy
 
 - Verified: Energy throttle math implemented in `src/state/store.ts` and used by `src/ecs/systems/power.ts` and `src/ecs/systems/mining.ts` to scale consumption and mining rates.
 - Remaining: add per-drone battery fields to `DroneEntity`, implement per-drone drain/charge allocation, and surface HUD indicators. Marking TASK006 In Progress.
+
+### 2025-10-16
+
+- Added drone battery fields, helper utilities, and updated travel/mining to consume per-drone energy with throttle floor clamping.
+- Reworked the power system to route solar/storage output into docked-drone charging while keeping stored energy non-negative.
+- Extended test suite with travel, mining, and power coverage for drained batteries and throttled progress; README documents the new behaviour. Marking TASK006 Completed.

--- a/memory/tasks/TASK007-seeded-rng.md
+++ b/memory/tasks/TASK007-seeded-rng.md
@@ -1,6 +1,6 @@
 # TASK007 - Seeded RNG
 
-**Status:** In Progress  
+**Status:** Completed
 **Added:** 2025-10-16  
 **Updated:** 2025-10-16
 
@@ -20,11 +20,11 @@ Create `src/lib/rng.ts` with Mulberry32 or similar, wire calls through math/ecs 
 
 ## Subtasks
 
-| ID | Description | Status | Updated | Notes |
-| --- | ----------- | ------ | ------- | ----- |
-| 7.1 | Implement RNG util | Not Started | 2025-10-16 | No `src/lib/rng.ts` found; random helpers still use Math.random in `src/lib/math.ts`. |
-| 7.2 | Persist seed in snapshot | Completed | 2025-02-14 | `rngSeed` included in `StoreSnapshot` and `serializeStore`/`importState` roundtrip tested in `src/state/store.test.ts`. |
-| 7.3 | Wire RNG to world generation | Partially Completed | 2025-02-14 | `createAsteroid` and world generation still call `randomRange`/Math.random; needs wiring to accept RNG instance for determinism. |
+| ID  | Description                  | Status    | Updated    | Notes                                                                                                                   |
+| --- | ---------------------------- | --------- | ---------- | ----------------------------------------------------------------------------------------------------------------------- |
+| 7.1 | Implement RNG util           | Completed | 2025-10-16 | Added `src/lib/rng.ts` with Mulberry32 generator, helpers, and deterministic unit tests.                                |
+| 7.2 | Persist seed in snapshot     | Completed | 2025-02-14 | `rngSeed` included in `StoreSnapshot` and `serializeStore`/`importState` roundtrip tested in `src/state/store.test.ts`. |
+| 7.3 | Wire RNG to world generation | Completed | 2025-10-16 | World creation, asteroid spawning, and math helpers now accept injected RNG instances derived from the store seed.      |
 
 ## Acceptance Criteria
 
@@ -36,3 +36,7 @@ Create `src/lib/rng.ts` with Mulberry32 or similar, wire calls through math/ecs 
 
 - Verified: `rngSeed` is persisted and import/export roundtrips retain the seed (`src/state/store.test.ts`).
 - Remaining: add a deterministic RNG utility (`src/lib/rng.ts`) and update `src/lib/math.ts` and world generation to use an injected RNG instance for reproducible generation.
+
+### 2025-10-16
+
+- Implemented the seeded RNG utility, updated math helpers and world generation to consume injected RNG instances, and added reproducibility tests for asteroid layouts. README now documents deterministic seeds. Marking TASK007 Completed.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -1,14 +1,14 @@
 # Task Index
 
-| Task ID | Name                                 | Status      | Updated    |
-| ------- | ------------------------------------ | ----------- | ---------- |
-| TASK001 | Core MVP Implementation              | Completed   | 2025-02-14 |
+| Task ID | Name                                    | Status      | Updated    |
+| ------- | --------------------------------------- | ----------- | ---------- |
+| TASK001 | Core MVP Implementation                 | Completed   | 2025-02-14 |
 | TASK002 | Persistence, Offline Catch-Up, Settings | In Progress | 2025-02-14 |
-| TASK003 | Spec Refresh for Current Implementation | Completed | 2025-02-15 |
-| TASK004 | Persistence Integration & Settings UI | Completed | 2025-10-16 |
-| TASK005 | Refinery ECS System & Offline Alignment | Completed | 2025-10-16 |
-| TASK006 | Energy Throttle & Per-Drone Battery | In Progress | 2025-10-16 |
-| TASK007 | Seeded RNG | In Progress | 2025-10-16 |
-| TASK008 | Visual Polish (Trails First) | Pending | 2025-10-16 |
-| TASK009 | Tests & CI | In Progress | 2025-10-16 |
-| TASK010 | Migration Helpers & Documentation | Pending | 2025-10-16 |
+| TASK003 | Spec Refresh for Current Implementation | Completed   | 2025-02-15 |
+| TASK004 | Persistence Integration & Settings UI   | Completed   | 2025-10-16 |
+| TASK005 | Refinery ECS System & Offline Alignment | Completed   | 2025-10-16 |
+| TASK006 | Energy Throttle & Per-Drone Battery     | Completed   | 2025-10-16 |
+| TASK007 | Seeded RNG                              | Completed   | 2025-10-16 |
+| TASK008 | Visual Polish (Trails First)            | Pending     | 2025-10-16 |
+| TASK009 | Tests & CI                              | In Progress | 2025-10-16 |
+| TASK010 | Migration Helpers & Documentation       | Pending     | 2025-10-16 |

--- a/src/ecs/energy.ts
+++ b/src/ecs/energy.ts
@@ -1,0 +1,37 @@
+import { clamp } from '@/lib/math';
+import type { DroneEntity } from '@/ecs/world';
+
+const EPSILON = 1e-4;
+
+export const computeDroneEnergyFraction = (drone: DroneEntity, throttleFloor: number) => {
+  if (drone.maxBattery <= 0) {
+    return 1;
+  }
+  const normalized = drone.battery / drone.maxBattery;
+  if (!Number.isFinite(normalized)) {
+    return 1;
+  }
+  return clamp(normalized, throttleFloor, 1);
+};
+
+export const consumeDroneEnergy = (
+  drone: DroneEntity,
+  dt: number,
+  throttleFloor: number,
+  rate: number,
+) => {
+  const fraction = computeDroneEnergyFraction(drone, throttleFloor);
+  if (dt <= 0 || rate <= 0) {
+    drone.charging = false;
+    return { fraction, consumed: 0 };
+  }
+  const consumed = Math.min(drone.battery, Math.max(0, rate * dt * fraction));
+  if (consumed > 0) {
+    drone.battery = Math.max(0, drone.battery - consumed);
+    if (drone.battery <= EPSILON) {
+      drone.battery = 0;
+    }
+  }
+  drone.charging = false;
+  return { fraction, consumed };
+};

--- a/src/ecs/systems/asteroids.test.ts
+++ b/src/ecs/systems/asteroids.test.ts
@@ -1,18 +1,17 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { createAsteroid } from '@/ecs/world';
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
+import { createRng } from '@/lib/rng';
 
 describe('ecs/systems/asteroids', () => {
   it('spawns richer asteroids with higher scanner level', () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0.5);
-    const samples = (level: number) =>
-      Array.from({ length: 20 }, () => createAsteroid(level)).reduce(
-        (sum, asteroid) => sum + asteroid.richness,
-        0,
-      ) / 20;
+    const samples = (level: number) => {
+      const rng = createRng(12345);
+      let total = 0;
+      for (let index = 0; index < 20; index += 1) {
+        total += createAsteroid(level, rng).richness;
+      }
+      return total / 20;
+    };
     const base = samples(0);
     const boosted = samples(5);
     expect(boosted).toBeGreaterThan(base);

--- a/src/ecs/systems/fleet.test.ts
+++ b/src/ecs/systems/fleet.test.ts
@@ -5,7 +5,7 @@ import { createStoreInstance } from '@/state/store';
 
 describe('ecs/systems/fleet', () => {
   it('maintains drone count according to module level', () => {
-    const world = createGameWorld(0);
+    const world = createGameWorld({ asteroidCount: 0 });
     const store = createStoreInstance();
     const system = createFleetSystem(world, store);
     system(0.1);

--- a/src/ecs/systems/mining.ts
+++ b/src/ecs/systems/mining.ts
@@ -1,13 +1,13 @@
 import type { GameWorld } from '@/ecs/world';
-import { computeEnergyThrottle, type StoreApiType } from '@/state/store';
+import { consumeDroneEnergy } from '@/ecs/energy';
+import { DRONE_ENERGY_COST, type StoreApiType } from '@/state/store';
 
 export const createMiningSystem = (world: GameWorld, store: StoreApiType) => {
   const { droneQuery, asteroidQuery } = world;
   return (dt: number) => {
     if (dt <= 0) return;
-    const state = store.getState();
-    const throttle = computeEnergyThrottle(state);
-    if (throttle <= 0) return;
+    const { settings } = store.getState();
+    const throttleFloor = settings.throttleFloor;
     for (const drone of droneQuery) {
       if (drone.state !== 'mining') continue;
       const asteroid = asteroidQuery.entities.find((node) => node.id === drone.targetId);
@@ -24,7 +24,11 @@ export const createMiningSystem = (world: GameWorld, store: StoreApiType) => {
         drone.travel = null;
         continue;
       }
-      const mined = Math.min(drone.miningRate * throttle * dt, capacityLeft, asteroid.oreRemaining);
+      const { fraction } = consumeDroneEnergy(drone, dt, throttleFloor, DRONE_ENERGY_COST);
+      if (fraction <= 0) {
+        continue;
+      }
+      const mined = Math.min(drone.miningRate * fraction * dt, capacityLeft, asteroid.oreRemaining);
       if (mined <= 0) {
         drone.state = 'returning';
         drone.targetId = null;

--- a/src/ecs/systems/power.test.ts
+++ b/src/ecs/systems/power.test.ts
@@ -10,39 +10,52 @@ const addDrones = (world: ReturnType<typeof createGameWorld>, count: number) => 
 };
 
 describe('ecs/systems/power', () => {
-  it('scales consumption by energy throttle to allow recovery', () => {
-    const world = createGameWorld(0);
-    addDrones(world, 4);
+  it('charges idle drones using available stored energy', () => {
+    const world = createGameWorld({ asteroidCount: 0 });
+    addDrones(world, 1);
+    const [drone] = world.droneQuery.entities;
+    if (!drone) throw new Error('expected drone');
+    drone.state = 'idle';
+    drone.battery = 0;
+
     const store = createStoreInstance();
     store.setState((state) => ({
-      modules: { ...state.modules, droneBay: 4, solar: 0 },
       resources: { ...state.resources, energy: 10 },
-      settings: { ...state.settings, throttleFloor: 0.25 },
     }));
 
     const system = createPowerSystem(world, store);
     system(1);
 
     const { resources } = store.getState();
-    expect(resources.energy).toBeCloseTo(13.8, 5);
+    expect(drone.battery).toBeCloseTo(2.4, 5);
+    expect(resources.energy).toBeCloseTo(12.6, 5);
+    expect(drone.charging).toBe(true);
   });
 
-  it('maintains full consumption when energy is plentiful', () => {
-    const world = createGameWorld(0);
-    addDrones(world, 20);
+  it('avoids negative energy even with heavy charging demand', () => {
+    const world = createGameWorld({ asteroidCount: 0 });
+    addDrones(world, 4);
+    const drones = [...world.droneQuery.entities];
+    drones.forEach((drone) => {
+      drone.state = 'idle';
+      drone.battery = 0;
+    });
+
     const store = createStoreInstance();
     store.setState((state) => ({
-      modules: { ...state.modules, droneBay: 20, solar: 0 },
-      resources: { ...state.resources, energy: 100 },
-      settings: { ...state.settings, throttleFloor: 0.1 },
+      resources: { ...state.resources, energy: 0 },
     }));
 
     const system = createPowerSystem(world, store);
     system(1);
 
     const { resources } = store.getState();
-    const generation = 5; // solar level 0 => 5 energy per second
-    const consumption = 20 * 1.2; // twenty drones at full throttle
-    expect(resources.energy).toBeCloseTo(100 + generation - consumption, 5);
+    expect(resources.energy).toBeCloseTo(0, 5);
+    const batteries = drones.map((drone) => drone?.battery ?? 0).sort((a, b) => b - a);
+    expect(batteries[0]).toBeCloseTo(2.4, 5);
+    expect(batteries[1]).toBeCloseTo(2.4, 5);
+    expect(batteries[2]).toBeCloseTo(0.2, 5);
+    expect(batteries[3]).toBeCloseTo(0, 5);
+    expect(drones.some((drone) => drone?.charging === false && drone?.battery === 0)).toBe(true);
   });
 });

--- a/src/ecs/systems/refinery.test.ts
+++ b/src/ecs/systems/refinery.test.ts
@@ -16,7 +16,7 @@ const setupStore = () => {
 
 describe('ecs/systems/refinery', () => {
   it('shares refinery math with offline processing', () => {
-    const world = createGameWorld(0);
+    const world = createGameWorld({ asteroidCount: 0 });
     const store = setupStore();
     const mirrorStore = setupStore();
     const system = createRefinerySystem(world, store);
@@ -30,7 +30,7 @@ describe('ecs/systems/refinery', () => {
   });
 
   it('ignores non-positive timesteps', () => {
-    const world = createGameWorld(0);
+    const world = createGameWorld({ asteroidCount: 0 });
     const store = setupStore();
     const system = createRefinerySystem(world, store);
     const before = store.getState().resources;

--- a/src/ecs/systems/travel.test.ts
+++ b/src/ecs/systems/travel.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { createTravelSystem } from '@/ecs/systems/travel';
+import { createGameWorld, spawnDrone } from '@/ecs/world';
+import { createStoreInstance } from '@/state/store';
+import { Vector3 } from 'three';
+
+const setupTravelScenario = () => {
+  const world = createGameWorld({ asteroidCount: 0 });
+  const store = createStoreInstance();
+  const drone = spawnDrone(world);
+  drone.state = 'toAsteroid';
+  drone.travel = {
+    from: drone.position.clone(),
+    to: drone.position.clone().add(new Vector3(10, 0, 0)),
+    elapsed: 0,
+    duration: 1,
+  };
+  return { world, store, drone };
+};
+
+describe('ecs/systems/travel', () => {
+  it('advances travel proportionally to available battery', () => {
+    const { world, store, drone } = setupTravelScenario();
+    drone.battery = drone.maxBattery / 4;
+    store.setState((state) => ({
+      settings: { ...state.settings, throttleFloor: 0.2 },
+    }));
+
+    const system = createTravelSystem(world, store);
+    system(1);
+
+    expect(drone.travel?.elapsed).toBeCloseTo(0.25, 5);
+    expect(drone.battery).toBeCloseTo(drone.maxBattery / 4 - 0.3, 5);
+  });
+
+  it('applies throttle floor when battery is depleted', () => {
+    const { world, store, drone } = setupTravelScenario();
+    drone.battery = 0;
+    store.setState((state) => ({
+      settings: { ...state.settings, throttleFloor: 0.3 },
+    }));
+
+    const system = createTravelSystem(world, store);
+    system(1);
+
+    expect(drone.travel?.elapsed).toBeCloseTo(0.3, 5);
+    expect(drone.battery).toBe(0);
+  });
+});

--- a/src/ecs/systems/travel.ts
+++ b/src/ecs/systems/travel.ts
@@ -1,12 +1,17 @@
+import { consumeDroneEnergy } from '@/ecs/energy';
 import type { GameWorld } from '@/ecs/world';
+import { DRONE_ENERGY_COST, type StoreApiType } from '@/state/store';
 
-export const createTravelSystem = (world: GameWorld) => {
+export const createTravelSystem = (world: GameWorld, store: StoreApiType) => {
   const { droneQuery } = world;
   return (dt: number) => {
+    if (dt <= 0) return;
+    const throttleFloor = store.getState().settings.throttleFloor;
     for (const drone of droneQuery) {
       const travel = drone.travel;
       if (!travel) continue;
-      travel.elapsed = Math.min(travel.elapsed + dt, travel.duration);
+      const { fraction } = consumeDroneEnergy(drone, dt, throttleFloor, DRONE_ENERGY_COST);
+      travel.elapsed = Math.min(travel.elapsed + dt * fraction, travel.duration);
       const t = travel.duration > 0 ? travel.elapsed / travel.duration : 1;
       drone.position.lerpVectors(travel.from, travel.to, t);
       if (travel.elapsed >= travel.duration - 1e-4) {

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -1,18 +1,26 @@
 import { Vector3 } from 'three';
+import type { RandomSource } from '@/lib/rng';
 
 export const TAU = Math.PI * 2;
 
 export const clamp = (value: number, min: number, max: number) =>
   Math.max(min, Math.min(max, value));
 
-export const randomRange = (min: number, max: number) => min + Math.random() * (max - min);
+export const randomRange = (min: number, max: number, rng?: RandomSource) =>
+  min + (rng?.next() ?? Math.random()) * (max - min);
 
-export const randomInt = (min: number, max: number) => Math.floor(randomRange(min, max + 1));
+export const randomInt = (min: number, max: number, rng?: RandomSource) =>
+  Math.floor(randomRange(min, max + 1, rng));
 
-export const randomOnRing = (minRadius: number, maxRadius: number, yRange = 2) => {
-  const radius = randomRange(minRadius, maxRadius);
-  const angle = randomRange(0, TAU);
-  const y = randomRange(-yRange, yRange);
+export const randomOnRing = (
+  minRadius: number,
+  maxRadius: number,
+  yRange = 2,
+  rng?: RandomSource,
+) => {
+  const radius = randomRange(minRadius, maxRadius, rng);
+  const angle = randomRange(0, TAU, rng);
+  const y = randomRange(-yRange, yRange, rng);
   return new Vector3(Math.cos(angle) * radius, y, Math.sin(angle) * radius);
 };
 

--- a/src/lib/rng.test.ts
+++ b/src/lib/rng.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { createRng } from '@/lib/rng';
+
+describe('lib/rng', () => {
+  it('produces deterministic sequences for the same seed', () => {
+    const first = createRng(123456789);
+    const second = createRng(123456789);
+    const sequenceLength = 5;
+    const a = Array.from({ length: sequenceLength }, () => first.next());
+    const b = Array.from({ length: sequenceLength }, () => second.next());
+    expect(b).toEqual(a);
+  });
+
+  it('diverges when seeds differ', () => {
+    const first = createRng(123456789);
+    const second = createRng(987654321);
+    expect(second.next()).not.toBeCloseTo(first.next());
+  });
+
+  it('supports ranged helpers', () => {
+    const rng = createRng(42);
+    const int = rng.nextInt(1, 3);
+    expect(int).toBeGreaterThanOrEqual(1);
+    expect(int).toBeLessThanOrEqual(3);
+    const value = rng.nextRange(-2, 2);
+    expect(value).toBeGreaterThanOrEqual(-2);
+    expect(value).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/lib/rng.ts
+++ b/src/lib/rng.ts
@@ -1,0 +1,59 @@
+const UINT32_MAX = 0xffffffff;
+
+export interface RandomSource {
+  next(): number;
+}
+
+export interface RandomGenerator extends RandomSource {
+  readonly seed: number;
+  nextInt(min: number, max: number): number;
+  nextRange(min: number, max: number): number;
+}
+
+const normalizeSeed = (seed: number) => {
+  if (!Number.isFinite(seed)) {
+    return 1;
+  }
+  const normalized = seed >>> 0;
+  return normalized === 0 ? 1 : normalized;
+};
+
+export const createRng = (seed: number): RandomGenerator => {
+  let state = normalizeSeed(seed);
+
+  const next = () => {
+    state += 0x6d2b79f5;
+    let t = Math.imul(state ^ (state >>> 15), state | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / (UINT32_MAX + 1);
+  };
+
+  const nextInRange = (min: number, max: number) => {
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      throw new Error('min and max must be finite numbers');
+    }
+    if (max < min) {
+      [min, max] = [max, min];
+    }
+    return min + next() * (max - min);
+  };
+
+  return {
+    get seed() {
+      return state;
+    },
+    next,
+    nextRange: nextInRange,
+    nextInt: (min: number, max: number) => {
+      if (!Number.isFinite(min) || !Number.isFinite(max)) {
+        throw new Error('min and max must be finite numbers');
+      }
+      const floorMin = Math.ceil(Math.min(min, max));
+      const floorMax = Math.floor(Math.max(min, max));
+      if (floorMax < floorMin) {
+        return floorMin;
+      }
+      return floorMin + Math.floor((floorMax - floorMin + 1) * next());
+    },
+  };
+};

--- a/src/r3f/Scene.tsx
+++ b/src/r3f/Scene.tsx
@@ -26,7 +26,7 @@ export const Scene = () => {
       fleet: createFleetSystem(gameWorld, store),
       asteroids: createAsteroidSystem(gameWorld, store),
       droneAI: createDroneAISystem(gameWorld, store),
-      travel: createTravelSystem(gameWorld),
+      travel: createTravelSystem(gameWorld, store),
       mining: createMiningSystem(gameWorld, store),
       unload: createUnloadSystem(gameWorld, store),
       power: createPowerSystem(gameWorld, store),

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -17,7 +17,7 @@ const STORAGE_PER_LEVEL = 100;
 const BASE_ENERGY_CAP = 100;
 const ENERGY_PER_SOLAR = 25;
 const SOLAR_BASE_GEN = 5;
-const DRONE_ENERGY_COST = 1.2;
+export const DRONE_ENERGY_COST = 1.2;
 
 const initialSettings: StoreSettings = {
   autosaveEnabled: true,


### PR DESCRIPTION
## Summary
- add per-drone battery data and shared energy helpers, updating travel, mining, and power systems to consume and recharge drone batteries smoothly
- introduce a deterministic RNG utility and route world generation/math helpers through seeded instances for reproducible asteroid layouts
- expand unit coverage for travel, mining, power, and RNG while refreshing documentation, requirements, and memory tasks to reflect the new behaviour

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npx prettier --check src/ecs/systems/power.ts src/lib/math.ts
- npx prettier --check memory/tasks/TASK006-energy-throttle.md memory/tasks/TASK007-seeded-rng.md memory/tasks/_index.md

------
https://chatgpt.com/codex/tasks/task_e_68f0a94e5f88832a9b41d3cfb8f088ae