### PR TITLE
Add drone trails toggle and refresh persistence spec

### DIFF
--- a/memory/activeContext.md
+++ b/memory/activeContext.md
@@ -2,16 +2,16 @@
 
 ## Current Focus
 
-Stabilize the new per-drone energy systems and seeded RNG pipeline from TASK006/TASK007, and prepare UI follow-ups for battery HUD feedback.
+Deliver visual polish milestones starting with drone trails while keeping persistence/settings docs aligned with the shipped implementation.
 
 ## Recent Changes
 
-- Introduced per-drone battery fields, travel/mining throttling, and charging allocation with new unit coverage.
-- Added deterministic RNG utility, updated world generation to consume seeded randomness, and expanded tests/README accordingly.
-- Maintained persistence hooks so RNG seeds and energy settings continue to roundtrip through snapshots.
+- Finalized spec/persistence backlog items for TASK002, documenting the live manager wiring and Settings defaults.
+- Added `settings.showTrails` persistence, Settings toggle, and new tests covering normalization/export/import paths.
+- Implemented `TrailBuffer` + `DroneTrails` to render fading path lines behind drones with a single draw call.
 
 ## Next Steps
 
-- Monitor simulation telemetry to validate long-run battery balance and identify UI indicators needed for individual drones.
-- Plan HUD work to surface average/low battery warnings and evaluate Settings copy for throttle floor guidance.
-- Review RNG integration with save import/export flows and scope any reset/regeneration hooks needed for world rebuilds.
+- Validate runtime performance of the new trails on low-spec profiles and provide screenshots for design review.
+- Scope factory/scanner visual polish follow-ups and related Settings toggles.
+- Plan HUD indicators for energy throttling/battery state once visual polish baseline ships.

--- a/memory/designs/DES007-visual-polish.md
+++ b/memory/designs/DES007-visual-polish.md
@@ -1,12 +1,59 @@
 # DES007 — Visual Polish (Trails First)
 
-**Status:** Draft
+**Status:** In Progress
 **Created:** 2025-10-16
+**Updated:** 2025-10-16
 
 ## Summary
 
-Design options for drone trails, factory visual upgrades, and scanner highlights with performance toggles exposed in Settings.
+Add configurable drone trail effects that convey motion without harming performance, expose the toggle in Settings, and document the feature for persistence and spec consumers. Defer factory/scanner polish to follow-up tasks.
 
-## Notes
+## Goals
 
-- Prefer instanced geometry and optional effects behind Settings toggles. Add colorblind-friendly palettes.
+- Render light-weight drone trails that match instanced drone colors and fade over time.
+- Allow players to disable trails from the Settings panel; persist the choice across sessions/import/export.
+- Keep the trail buffers GPU-friendly (single `LineSegments` draw call) and clamp to the existing drone cap (128).
+- Update the spec and requirements to reflect persistence completion and the new visual toggle.
+
+## Architecture
+
+- **State:** Extend `StoreSettings` with `showTrails: boolean` (default `true`). Normalized in `normalizeSettings`, serialized with snapshots, and observed by the scene.
+- **UI:** Add a "Drone trails" toggle row to `SettingsPanel`. When toggled, dispatches `updateSettings({ showTrails })`.
+- **Rendering:** Introduce `DroneTrails` under `src/r3f/` using a shared `TrailBuffer` helper. The helper maintains a ring-buffer of recent positions per drone slot (aligned with instancing order) and writes batched position/color attributes for a `LineSegments` geometry. Colors lerp toward the scene background per segment for a fade effect.
+- **Scene Integration:** `Scene` reads `settings.showTrails` via `useStore` and mounts `<DroneTrails />` when enabled.
+- **Documentation:** Refresh `spec/spec-full-idea.md` to mark persistence as implemented, describe Settings/offline behavior, and mention the new trails toggle under rendering/UX.
+
+## Data Flow
+
+1. Settings UI updates `showTrails` in the store.
+2. Persistence manager serializes/deserializes the new flag with other settings; import/export include it automatically.
+3. `Scene` re-renders when `showTrails` changes, mounting/unmounting `DroneTrails`.
+4. On each frame, `DroneTrails` pulls current drones from `gameWorld`, pushes their positions into the `TrailBuffer`, rebuilds the geometry attributes, and updates draw range based on active drone count.
+
+## Interfaces
+
+- `StoreSettings.showTrails: boolean` — persisted and normalized.
+- `TrailBuffer.update(drones: readonly DroneSnapshot[]): void` — updates internal typed arrays and exposes `positions`, `colors`, and `vertexCount` for the geometry.
+- `DroneTrails` component consumes `TrailBuffer`, writes arrays into a shared `BufferGeometry`, and marks attributes dirty in `useFrame`.
+
+`DroneSnapshot` will mirror the subset of `DroneEntity` that the buffer needs (`position`, `state`).
+
+## Implementation Plan
+
+1. Extend store settings/persistence serialization to include `showTrails`; add normalization and tests for roundtrips.
+2. Update `SettingsPanel` UI + tests to surface the new toggle and confirm it updates the store.
+3. Implement `TrailBuffer` helper with unit tests covering history rotation, color fade, and clamped vertex counts.
+4. Add `DroneTrails` component that uses `TrailBuffer` and conditionally render it from `Scene` based on `settings.showTrails`.
+5. Refresh the spec/requirements and memory/task files to mark TASK002 complete and document the new visual polish milestone.
+
+## Risks & Mitigations
+
+- **Performance:** Updating typed arrays each frame could be expensive. Mitigate by keeping history length short (e.g., 12 samples) and performing simple `Float32Array` shifts. Profiling can guide future optimizations.
+- **Store migrations:** Ensure the new `showTrails` default is applied when older saves lack the field via `normalizeSettings`.
+- **Tests in headless environment:** R3F components rely on WebGL. Keep render logic in a pure helper to allow Vitest coverage without needing a WebGL context.
+
+## Follow-ups
+
+- Factory lighting/scanner highlight polish.
+- Additional Settings toggles for bloom/particle density once effects exist.
+- Optional battery HUD indicators tied to energy throttle work.

--- a/memory/progress.md
+++ b/memory/progress.md
@@ -12,8 +12,10 @@
 - Refined offline catch-up to reuse the store's refinery logic directly, emit telemetry for ore/bars processed, and surface load-time summaries via persistence logging.
 - Delivered per-drone battery throttling, charging allocation, and regression tests covering mining, travel, and power systems.
 - Implemented seeded RNG utility and routed world generation/math helpers through the stored seed with deterministic unit coverage and README updates.
+- Documented persistence manager integration/spec updates and introduced the `showTrails` Settings toggle alongside the new drone trail renderer and tests.
 
 ## Open Items
 
 - Track UI follow-up for surfacing per-drone battery levels and throttle warnings in the HUD.
 - Validate seeded RNG integration across save import/export flows and plan any reset tooling.
+- Capture performance telemetry for drone trails and scope factory/scanner visual polish follow-ups.

--- a/memory/requirements.md
+++ b/memory/requirements.md
@@ -35,3 +35,11 @@ WHEN a drone consumes more power than the grid can supply, THE SYSTEM SHALL slow
 ## RQ-009 Seeded World Generation
 
 WHEN a new world is generated with a given RNG seed, THE SYSTEM SHALL place asteroids in identical positions and with the same attributes whenever that seed is reused, while different seeds yield different layouts. [Acceptance: Unit tests construct worlds with shared/different seeds and compare asteroid distributions.]
+
+## RQ-010 Visual Effects Toggle Persistence
+
+WHEN the player changes the drone trails preference in Settings, THE SYSTEM SHALL persist the `showTrails` flag across autosaves and import/export operations and apply the new value within the next rendered frame. [Acceptance: Unit tests cover settings normalization/serialization, and UI tests assert the toggle updates the store and re-renders the scene without errors.]
+
+## RQ-011 Drone Trail Rendering
+
+WHEN drones travel or change state, THE SYSTEM SHALL render a fading trail indicating their recent path using at most one additional draw call and no more than 12 stored points per drone, honoring the global `showTrails` toggle. [Acceptance: Unit tests validate the trail buffer helper's vertex counts/color gradients, and manual verification confirms the toggle hides/shows trails without performance regressions.]

--- a/memory/tasks/TASK002-persistence-offline.md
+++ b/memory/tasks/TASK002-persistence-offline.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In Progress
+Completed
 
 ## Summary
 
@@ -59,6 +59,11 @@ Implement save/load with autosave and offline simulation, create settings UI for
 - Updated the refinery ECS system to invoke the store's `processRefinery` action so live ticks and offline loops share the same execution path.
 - Refactored offline simulation to drive `processRefinery` directly, returning a telemetry report for ore consumption and bar output.
 - Logged offline recap summaries during persistence load to aid balancing and regression triage, with refreshed Vitest coverage for the new report contract.
+
+### 2025-10-17
+
+- Closed the lingering spec backlog by documenting the shipped persistence manager wiring, shared refinery helpers, and Settings defaults (including the new trails toggle).
+- Confirmed Settings serialization/import now includes `showTrails`, ensuring persistence tasks no longer block visual polish follow-ups.
 
 ## Updated Iteration Plan (2025-02-18)
 

--- a/memory/tasks/TASK008-visual-polish.md
+++ b/memory/tasks/TASK008-visual-polish.md
@@ -1,8 +1,8 @@
 # TASK008 - Visual Polish (Trails First)
 
-**Status:** Pending  
-**Added:** 2025-10-16  
-**Updated:** 2025-10-16
+**Status:** In Progress
+**Added:** 2025-10-16
+**Updated:** 2025-10-17
 
 ## Original Request
 
@@ -14,17 +14,19 @@ Prototype trails in `src/r3f/Drones.tsx` using instancing or Drei `Trail`, add S
 
 ## Implementation Plan
 
-1. Implement trails prototype and performance test.
-1. Add Settings toggle and defaults.
-1. Iterate on factory visuals and scanner highlights.
+1. Extend store settings persistence with a `showTrails` boolean defaulting to true; update normalization and tests.
+2. Surface a "Drone trails" toggle in the Settings panel that updates/persists the new field.
+3. Create a GPU-friendly `DroneTrails` renderer (single `LineSegments` with fading colors) backed by a testable buffer helper.
+4. Conditionally mount the new renderer from `Scene` when the toggle is enabled.
+5. Refresh spec + memory docs to capture persistence completion and the new visuals toggle.
 
 ## Subtasks
 
-| ID | Description | Status | Updated | Notes |
-| --- | ----------- | ------ | ------- | ----- |
-| 8.1 | Trails prototype | Not Started | 2025-10-16 | `src/r3f/Drones.tsx` uses instancing but no trail implementation present. |
-| 8.2 | Settings toggle | Not Started | 2025-10-16 | Settings UI contains general toggles but no trail-specific toggle implemented. |
-| 8.3 | Factory visuals | Not Started | 2025-10-16 | Factory visual improvements remain to be implemented. |
+| ID  | Description      | Status      | Updated    | Notes                                                                |
+| --- | ---------------- | ----------- | ---------- | -------------------------------------------------------------------- |
+| 8.1 | Trails prototype | Completed   | 2025-10-17 | `TrailBuffer` + `DroneTrails` render fading line segments per drone. |
+| 8.2 | Settings toggle  | Completed   | 2025-10-17 | Settings panel exposes persisted `showTrails` toggle with tests.     |
+| 8.3 | Factory visuals  | Not Started | 2025-10-16 | Deferred to follow-up task.                                          |
 
 ## Acceptance Criteria
 
@@ -35,3 +37,8 @@ Prototype trails in `src/r3f/Drones.tsx` using instancing or Drei `Trail`, add S
 ### 2025-10-16
 
 - Verified: instanced drone rendering exists (`src/r3f/Drones.tsx`). Trails and additional visual polish remain TODO.
+
+### 2025-10-17
+
+- Implemented `TrailBuffer` helper and `DroneTrails` renderer to draw single-call line segments with fading colors per drone.
+- Added `settings.showTrails` persistence + Settings toggle, updated tests/spec, and wired `Scene` to mount trails based on the new flag.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -3,12 +3,12 @@
 | Task ID | Name                                    | Status      | Updated    |
 | ------- | --------------------------------------- | ----------- | ---------- |
 | TASK001 | Core MVP Implementation                 | Completed   | 2025-02-14 |
-| TASK002 | Persistence, Offline Catch-Up, Settings | In Progress | 2025-02-14 |
+| TASK002 | Persistence, Offline Catch-Up, Settings | Completed   | 2025-10-17 |
 | TASK003 | Spec Refresh for Current Implementation | Completed   | 2025-02-15 |
 | TASK004 | Persistence Integration & Settings UI   | Completed   | 2025-10-16 |
 | TASK005 | Refinery ECS System & Offline Alignment | Completed   | 2025-10-16 |
 | TASK006 | Energy Throttle & Per-Drone Battery     | Completed   | 2025-10-16 |
 | TASK007 | Seeded RNG                              | Completed   | 2025-10-16 |
-| TASK008 | Visual Polish (Trails First)            | Pending     | 2025-10-16 |
+| TASK008 | Visual Polish (Trails First)            | In Progress | 2025-10-17 |
 | TASK009 | Tests & CI                              | In Progress | 2025-10-16 |
 | TASK010 | Migration Helpers & Documentation       | Pending     | 2025-10-16 |

--- a/src/r3f/DroneTrails.tsx
+++ b/src/r3f/DroneTrails.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { BufferAttribute } from 'three';
+import type { LineSegments } from 'three';
+import { gameWorld } from '@/ecs/world';
+import { TrailBuffer } from '@/r3f/trailsBuffer';
+
+export const DroneTrails = () => {
+  const lineRef = useRef<LineSegments>(null);
+  const buffer = useMemo(() => new TrailBuffer(), []);
+  const { droneQuery } = gameWorld;
+
+  useEffect(() => {
+    droneQuery.connect();
+    return () => {
+      droneQuery.disconnect();
+    };
+  }, [droneQuery]);
+
+  useEffect(() => {
+    const line = lineRef.current;
+    if (!line) return;
+    line.frustumCulled = false;
+    const geometry = line.geometry;
+    geometry.setAttribute('position', new BufferAttribute(buffer.positions, 3));
+    geometry.setAttribute('color', new BufferAttribute(buffer.colors, 3));
+  }, [buffer]);
+
+  useFrame(() => {
+    const line = lineRef.current;
+    if (!line) return;
+    const geometry = line.geometry;
+    buffer.update(droneQuery.entities);
+    const positionAttr = geometry.getAttribute('position') as BufferAttribute;
+    const colorAttr = geometry.getAttribute('color') as BufferAttribute;
+    positionAttr.needsUpdate = true;
+    colorAttr.needsUpdate = true;
+    geometry.setDrawRange(0, buffer.vertexCount);
+    if (buffer.vertexCount > 0 && !geometry.boundingSphere) {
+      geometry.computeBoundingSphere();
+    }
+  });
+
+  return (
+    <lineSegments ref={lineRef}>
+      <bufferGeometry />
+      <lineBasicMaterial vertexColors transparent opacity={0.85} />
+    </lineSegments>
+  );
+};

--- a/src/r3f/Drones.tsx
+++ b/src/r3f/Drones.tsx
@@ -1,33 +1,17 @@
 import { useFrame } from '@react-three/fiber';
 import { useEffect, useRef } from 'react';
 import type { InstancedMesh } from 'three';
-import { Color, Matrix4, Quaternion, Vector3 } from 'three';
+import { Matrix4, Quaternion, Vector3, Color } from 'three';
 import { gameWorld } from '@/ecs/world';
+import { colorForState } from '@/r3f/droneColors';
 
 const DRONE_LIMIT = 128;
-const idleColor = new Color('#94a3b8');
-const miningColor = new Color('#f97316');
-const returningColor = new Color('#22d3ee');
-const unloadingColor = new Color('#cbd5f5');
 const baseMatrix = new Matrix4();
 const orientation = new Quaternion();
 const scale = new Vector3(0.25, 0.6, 0.25);
 const forward = new Vector3(0, 1, 0);
 const direction = new Vector3();
 const color = new Color();
-
-const colorForState = (state: string) => {
-  switch (state) {
-    case 'mining':
-      return miningColor;
-    case 'returning':
-      return returningColor;
-    case 'unloading':
-      return unloadingColor;
-    default:
-      return idleColor;
-  }
-};
 
 export const Drones = () => {
   const ref = useRef<InstancedMesh>(null);

--- a/src/r3f/Scene.tsx
+++ b/src/r3f/Scene.tsx
@@ -2,7 +2,7 @@ import { useFrame } from '@react-three/fiber';
 import { Suspense, useMemo } from 'react';
 import { Stars } from '@react-three/drei';
 import { gameWorld } from '@/ecs/world';
-import { storeApi } from '@/state/store';
+import { storeApi, useStore } from '@/state/store';
 import { createTimeSystem } from '@/ecs/systems/time';
 import { createFleetSystem } from '@/ecs/systems/fleet';
 import { createAsteroidSystem } from '@/ecs/systems/asteroids';
@@ -15,11 +15,13 @@ import { createRefinerySystem } from '@/ecs/systems/refinery';
 import { Factory } from '@/r3f/Factory';
 import { Asteroids } from '@/r3f/Asteroids';
 import { Drones } from '@/r3f/Drones';
+import { DroneTrails } from '@/r3f/DroneTrails';
 
 type SystemRunner = (dt: number) => void;
 
 export const Scene = () => {
   const time = useMemo(() => createTimeSystem(0.1), []);
+  const showTrails = useStore((state) => state.settings.showTrails);
   const systems = useMemo(() => {
     const store = storeApi;
     return {
@@ -65,6 +67,7 @@ export const Scene = () => {
         <Factory />
         <Asteroids />
         <Drones />
+        {showTrails ? <DroneTrails /> : null}
       </Suspense>
     </>
   );

--- a/src/r3f/droneColors.ts
+++ b/src/r3f/droneColors.ts
@@ -1,0 +1,22 @@
+import { Color } from 'three';
+import type { DroneState } from '@/ecs/world';
+
+const idleColor = new Color('#94a3b8');
+const miningColor = new Color('#f97316');
+const returningColor = new Color('#22d3ee');
+const unloadingColor = new Color('#cbd5f5');
+
+export const colorForState = (state: DroneState) => {
+  switch (state) {
+    case 'mining':
+      return miningColor;
+    case 'returning':
+      return returningColor;
+    case 'unloading':
+      return unloadingColor;
+    default:
+      return idleColor;
+  }
+};
+
+export { idleColor, miningColor, returningColor, unloadingColor };

--- a/src/r3f/trailsBuffer.test.ts
+++ b/src/r3f/trailsBuffer.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { Color, Vector3 } from 'three';
+import { TrailBuffer, type DroneTrailSource } from '@/r3f/trailsBuffer';
+import { colorForState } from '@/r3f/droneColors';
+
+describe('r3f/trailsBuffer', () => {
+  it('seeds history with the current position when a new drone id appears', () => {
+    const background = new Color('#000000');
+    const buffer = new TrailBuffer({ points: 4, background, limit: 2 });
+    const drone: DroneTrailSource = { id: 'd1', position: new Vector3(1, 2, 3), state: 'mining' };
+    const vertices = buffer.update([drone]);
+    expect(vertices).toBe(6); // (points - 1) * 2 vertices
+
+    const positions = Array.from(buffer.positions.slice(0, 6));
+    expect(positions).toEqual([1, 2, 3, 1, 2, 3]);
+
+    const baseColor = colorForState('mining').clone();
+    const expectedEnd = baseColor.clone().lerp(background, 1 / 3);
+    expect(buffer.colors[0]).toBeCloseTo(baseColor.r, 5);
+    expect(buffer.colors[1]).toBeCloseTo(baseColor.g, 5);
+    expect(buffer.colors[2]).toBeCloseTo(baseColor.b, 5);
+    expect(buffer.colors[3]).toBeCloseTo(expectedEnd.r, 5);
+    expect(buffer.colors[4]).toBeCloseTo(expectedEnd.g, 5);
+    expect(buffer.colors[5]).toBeCloseTo(expectedEnd.b, 5);
+  });
+
+  it('shifts history forward as drones move', () => {
+    const buffer = new TrailBuffer({ points: 3, limit: 1 });
+    const drone: DroneTrailSource = { id: 'd1', position: new Vector3(0, 0, 0), state: 'idle' };
+    buffer.update([drone]);
+    drone.position.set(5, 0, 0);
+    buffer.update([drone]);
+    const positions = Array.from(buffer.positions.slice(0, 6));
+    expect(positions).toEqual([5, 0, 0, 0, 0, 0]);
+  });
+
+  it('clears trailing history when drones are removed or slots reused', () => {
+    const buffer = new TrailBuffer({ points: 3, limit: 2 });
+    const droneA: DroneTrailSource = { id: 'a', position: new Vector3(1, 0, 0), state: 'idle' };
+    const droneB: DroneTrailSource = { id: 'b', position: new Vector3(2, 0, 0), state: 'idle' };
+    buffer.update([droneA, droneB]);
+    buffer.update([]);
+    expect(buffer.vertexCount).toBe(0);
+    expect(buffer.positions.every((value) => value === 0)).toBe(true);
+
+    const droneC: DroneTrailSource = { id: 'c', position: new Vector3(3, 0, 0), state: 'idle' };
+    buffer.update([droneC]);
+    const positions = Array.from(buffer.positions.slice(0, 6));
+    expect(positions).toEqual([3, 0, 0, 3, 0, 0]);
+  });
+
+  it('respects the configured limit when more drones are provided', () => {
+    const buffer = new TrailBuffer({ limit: 1, points: 3 });
+    const droneA: DroneTrailSource = { id: 'a', position: new Vector3(0, 0, 0), state: 'idle' };
+    const droneB: DroneTrailSource = { id: 'b', position: new Vector3(1, 0, 0), state: 'idle' };
+    const vertices = buffer.update([droneA, droneB]);
+    expect(vertices).toBe(4);
+    const positions = Array.from(buffer.positions.slice(0, 6));
+    expect(positions).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+});

--- a/src/r3f/trailsBuffer.ts
+++ b/src/r3f/trailsBuffer.ts
@@ -1,0 +1,125 @@
+import { Color } from 'three';
+import type { Vector3 } from 'three';
+import type { DroneState } from '@/ecs/world';
+import { colorForState } from '@/r3f/droneColors';
+
+export interface DroneTrailSource {
+  id: string;
+  position: Vector3;
+  state: DroneState;
+}
+
+export interface TrailBufferConfig {
+  limit?: number;
+  points?: number;
+  background?: Color;
+}
+
+const DEFAULT_LIMIT = 128;
+const DEFAULT_POINTS = 12;
+const DEFAULT_BACKGROUND = new Color('#040713');
+
+export class TrailBuffer {
+  readonly limit: number;
+  readonly points: number;
+  readonly positions: Float32Array;
+  readonly colors: Float32Array;
+  vertexCount = 0;
+
+  private readonly background: Color;
+  private readonly histories: Float32Array[];
+  private readonly ids: (string | null)[];
+  private readonly tmpColor = new Color();
+  private readonly scratch = new Color();
+  private readonly verticesPerDrone: number;
+  private readonly floatsPerDrone: number;
+
+  constructor(config: TrailBufferConfig = {}) {
+    this.limit = config.limit ?? DEFAULT_LIMIT;
+    this.points = Math.max(2, config.points ?? DEFAULT_POINTS);
+    this.background = config.background ?? DEFAULT_BACKGROUND;
+    this.verticesPerDrone = (this.points - 1) * 2;
+    this.floatsPerDrone = this.verticesPerDrone * 3;
+    this.positions = new Float32Array(this.limit * this.floatsPerDrone);
+    this.colors = new Float32Array(this.limit * this.floatsPerDrone);
+    this.histories = Array.from({ length: this.limit }, () => new Float32Array(this.points * 3));
+    this.ids = Array.from({ length: this.limit }, () => null);
+  }
+
+  update(drones: readonly DroneTrailSource[]) {
+    const count = Math.min(drones.length, this.limit);
+    let positionOffset = 0;
+    let colorOffset = 0;
+
+    for (let i = 0; i < count; i += 1) {
+      const drone = drones[i];
+      const history = this.histories[i];
+      const { x, y, z } = drone.position;
+      if (this.ids[i] !== drone.id) {
+        this.ids[i] = drone.id;
+        for (let h = 0; h < history.length; h += 3) {
+          history[h] = x;
+          history[h + 1] = y;
+          history[h + 2] = z;
+        }
+      } else {
+        for (let h = history.length - 3; h >= 3; h -= 3) {
+          history[h] = history[h - 3];
+          history[h + 1] = history[h - 2];
+          history[h + 2] = history[h - 1];
+        }
+        history[0] = x;
+        history[1] = y;
+        history[2] = z;
+      }
+
+      const baseColor = colorForState(drone.state);
+      for (let segment = 0; segment < this.points - 1; segment += 1) {
+        const startIndex = segment * 3;
+        const endIndex = startIndex + 3;
+        // position data
+        this.positions[positionOffset] = history[startIndex];
+        this.positions[positionOffset + 1] = history[startIndex + 1];
+        this.positions[positionOffset + 2] = history[startIndex + 2];
+        this.positions[positionOffset + 3] = history[endIndex];
+        this.positions[positionOffset + 4] = history[endIndex + 1];
+        this.positions[positionOffset + 5] = history[endIndex + 2];
+
+        // color data with fade toward background
+        this.writeColor(baseColor, segment / (this.points - 1), colorOffset);
+        this.writeColor(baseColor, (segment + 1) / (this.points - 1), colorOffset + 3);
+
+        positionOffset += 6;
+        colorOffset += 6;
+      }
+    }
+
+    // zero trailing data when fewer drones are active
+    this.positions.fill(0, positionOffset);
+    this.colors.fill(0, colorOffset);
+
+    // clear unused histories to avoid ghost trails next time the slot is reused
+    for (let i = count; i < this.limit; i += 1) {
+      this.ids[i] = null;
+      this.histories[i].fill(0);
+    }
+
+    this.vertexCount = count * this.verticesPerDrone;
+    return this.vertexCount;
+  }
+
+  private writeColor(base: Color, fade: number, offset: number) {
+    this.tmpColor.copy(base);
+    this.scratch.copy(this.background);
+    const t = Math.min(Math.max(fade, 0), 1);
+    this.tmpColor.lerp(this.scratch, t);
+    this.colors[offset] = this.tmpColor.r;
+    this.colors[offset + 1] = this.tmpColor.g;
+    this.colors[offset + 2] = this.tmpColor.b;
+  }
+}
+
+export const createTrailSources = (
+  drones: readonly DroneTrailSource[],
+  limit = DEFAULT_LIMIT,
+): readonly DroneTrailSource[] => drones.slice(0, limit);

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -55,15 +55,22 @@ describe('state/store', () => {
   it('updates settings with normalization and export/import roundtrips', () => {
     const store = createStoreInstance();
     const api = store.getState();
-    api.updateSettings({ autosaveInterval: 33.7, notation: 'engineering', offlineCapHours: -4 });
+    api.updateSettings({
+      autosaveInterval: 33.7,
+      notation: 'engineering',
+      offlineCapHours: -4,
+      showTrails: false,
+    });
     const afterUpdate = store.getState();
     expect(afterUpdate.settings.autosaveInterval).toBe(33);
     expect(afterUpdate.settings.notation).toBe('engineering');
     expect(afterUpdate.settings.offlineCapHours).toBe(0);
+    expect(afterUpdate.settings.showTrails).toBe(false);
 
     const snapshot = serializeStore(store.getState());
     expect(snapshot.settings.autosaveInterval).toBe(33);
     expect(snapshot.save.version).toBe(saveVersion);
+    expect(snapshot.settings.showTrails).toBe(false);
 
     const payload = JSON.stringify(snapshot);
     const parsed = parseSnapshot(payload);
@@ -74,6 +81,7 @@ describe('state/store', () => {
     expect(success).toBe(true);
     const imported = fresh.getState();
     expect(imported.settings.autosaveInterval).toBe(33);
+    expect(imported.settings.showTrails).toBe(false);
     expect(imported.resources.ore).toBe(snapshot.resources.ore);
   });
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -25,6 +25,7 @@ const initialSettings: StoreSettings = {
   offlineCapHours: 8,
   notation: 'standard',
   throttleFloor: 0.25,
+  showTrails: true,
 };
 
 export const saveVersion = SAVE_VERSION;
@@ -80,6 +81,7 @@ export interface StoreSettings {
   offlineCapHours: number;
   notation: NotationMode;
   throttleFloor: number;
+  showTrails: boolean;
 }
 
 export interface RefineryStats {
@@ -237,6 +239,8 @@ const normalizeSettings = (snapshot?: Partial<StoreSettings>): StoreSettings => 
     1,
     Math.max(0, coerceNumber(snapshot?.throttleFloor, initialSettings.throttleFloor)),
   ),
+  showTrails:
+    typeof snapshot?.showTrails === 'boolean' ? snapshot.showTrails : initialSettings.showTrails,
 });
 
 const normalizeSnapshot = (snapshot: Partial<StoreSnapshot>): StoreSnapshot => ({

--- a/src/ui/Settings.test.tsx
+++ b/src/ui/Settings.test.tsx
@@ -43,6 +43,7 @@ describe('ui/Settings', () => {
         offlineCapHours: 8,
         notation: 'standard',
         throttleFloor: 0.25,
+        showTrails: true,
       },
       save: { ...state.save, lastSave: 1_700_000_000_000 },
     }));
@@ -82,6 +83,16 @@ describe('ui/Settings', () => {
     const intervalInput = screen.getByLabelText<HTMLInputElement>(/autosave interval/i);
     fireEvent.change(intervalInput, { target: { value: '37.8' } });
     expect(storeApi.getState().settings.autosaveInterval).toBe(37);
+  });
+
+  it('toggles drone trails visibility', () => {
+    const persistence = createPersistenceMock();
+    render(<SettingsPanel onClose={() => undefined} persistence={persistence} />);
+
+    const toggle = screen.getByLabelText<HTMLInputElement>(/toggle drone trails/i);
+    expect(toggle.checked).toBe(true);
+    fireEvent.click(toggle);
+    expect(storeApi.getState().settings.showTrails).toBe(false);
   });
 
   it('invokes persistence export workflow when exporting', () => {

--- a/src/ui/Settings.tsx
+++ b/src/ui/Settings.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ChangeEventHandler,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEventHandler } from 'react';
 import { useStore } from '@/state/store';
 import type { PersistenceManager } from '@/state/persistence';
 
@@ -107,6 +100,10 @@ export const SettingsPanel = ({ onClose, persistence }: SettingsPanelProps) => {
     updateSettings({ throttleFloor: Number.isFinite(next) ? next : settings.throttleFloor });
   };
 
+  const handleTrails: ChangeEventHandler<HTMLInputElement> = (event) => {
+    updateSettings({ showTrails: event.target.checked });
+  };
+
   return (
     <div className="settings-backdrop" role="presentation">
       <div
@@ -190,6 +187,21 @@ export const SettingsPanel = ({ onClose, persistence }: SettingsPanelProps) => {
               aria-valuenow={Number(settings.throttleFloor.toFixed(2))}
             />
             <span className="settings-value">{Math.round(settings.throttleFloor * 100)}%</span>
+          </label>
+        </section>
+        <section className="settings-section">
+          <h3>Visuals</h3>
+          <label className="settings-row">
+            <span>
+              Drone trails
+              <small>Disable for performance on lower-end GPUs.</small>
+            </span>
+            <input
+              type="checkbox"
+              checked={settings.showTrails}
+              onChange={handleTrails}
+              aria-label="Toggle drone trails"
+            />
           </label>
         </section>
         <section className="settings-section">


### PR DESCRIPTION
## Summary
- add TrailBuffer/DroneTrails components to render configurable drone trails and reuse shared state colors
- persist the new `showTrails` setting, expose it in the Settings panel with coverage, and refresh the spec/requirements to mark persistence complete
- close out TASK002 and advance TASK008 by updating memory logs and context to document the visual polish milestone

## Testing
- npm run lint
- npm run typecheck
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68f0bfa88cc4832a9457ce028f5fadc5