### PR TITLE
Implement factory visuals and performance profile

### DIFF
--- a/memory/activeContext.md
+++ b/memory/activeContext.md
@@ -2,7 +2,7 @@
 
 ## Current Focus
 
-Deliver visual polish milestones starting with drone trails while keeping persistence/settings docs aligned with the shipped implementation.
+Implement factory visual upgrades (TASK011) including conveyors, transfer FX, and performance profiles while keeping persistence/settings docs aligned with the shipped implementation.
 
 ## Recent Changes
 
@@ -15,5 +15,5 @@ Deliver visual polish milestones starting with drone trails while keeping persis
 ## Next Steps
 
 - Validate runtime performance of the new trails on low-spec profiles and provide screenshots for design review.
-- Scope factory/scanner visual polish follow-ups and related Settings toggles.
+- Ship factory/scanner visual polish follow-ups and related Settings toggles, starting with TASK011, and close out remaining snapshot/perf coverage.
 - Plan HUD indicators for energy throttling/battery state once visual polish baseline ships.

--- a/memory/progress.md
+++ b/memory/progress.md
@@ -16,8 +16,10 @@
 
 - Implemented migration helpers (`src/state/migrations.ts`) to normalize legacy snapshots on load/import; README updated with save format and migration guidance.
 
+- Upgraded factory visuals with animated conveyors, transfer FX, boost pulses, and a settings-driven performance profile backed by ECS activity signals (TASK011).
+
 ## Open Items
 
 - Track UI follow-up for surfacing per-drone battery levels and throttle warnings in the HUD.
 - Validate seeded RNG integration across save import/export flows and plan any reset tooling.
-- Capture performance telemetry for drone trails and scope factory/scanner visual polish follow-ups.
+- Capture performance telemetry for drone trails and finalize factory snapshot/perf scene coverage for TASK011.

--- a/memory/requirements.md
+++ b/memory/requirements.md
@@ -43,3 +43,19 @@ WHEN the player changes the drone trails preference in Settings, THE SYSTEM SHAL
 ## RQ-011 Drone Trail Rendering
 
 WHEN drones travel or change state, THE SYSTEM SHALL render a fading trail indicating their recent path using at most one additional draw call and no more than 12 stored points per drone, honoring the global `showTrails` toggle. [Acceptance: Unit tests validate the trail buffer helper's vertex counts/color gradients, and manual verification confirms the toggle hides/shows trails without performance regressions.]
+
+## RQ-012 Factory Transfer Feedback
+
+WHEN a drone unloads cargo at the factory, THE SYSTEM SHALL emit a visible transfer effect that travels from the drone's approach vector into the factory within 0.75 seconds. [Acceptance: Unit tests cover event emission during unload, and manual verification confirms the effect spawns at runtime.]
+
+## RQ-013 Conveyor Activity Animation
+
+WHEN the refinery consumes ore, THE SYSTEM SHALL animate conveyor belts and ore items with speed proportional to the current processing intensity. [Acceptance: Unit tests assert processing intensity updates from the refinery system, and manual verification confirms belt motion while ore is processed.]
+
+## RQ-014 Boost Emissive Pulse
+
+WHEN refinery throughput exceeds the baseline by 20% or more, THE SYSTEM SHALL trigger a temporary boost pulse on factory materials that fades out over 1.5 seconds. [Acceptance: Unit tests verify boost levels decay over time and spike above the threshold, and manual verification confirms the emissive pulse.]
+
+## RQ-015 Performance Profiles
+
+WHEN the player selects a factory performance profile in Settings, THE SYSTEM SHALL adjust visual effect density to match the profile within the next rendered frame and persist the choice across saves. [Acceptance: Unit tests cover settings normalization/export, and manual verification confirms profiles toggle effect density.]

--- a/memory/tasks/TASK011-factory-visuals.md
+++ b/memory/tasks/TASK011-factory-visuals.md
@@ -1,8 +1,8 @@
 # TASK011 - Factory Visuals
 
-**Status:** Pending
+**Status:** In Progress
 **Added:** 2025-10-16
-**Updated:** 2025-10-16
+**Updated:** 2025-10-17
 
 ## Original Request
 
@@ -25,12 +25,12 @@ Factory visuals require art assets (sprites/meshes), cheap GPU techniques (UV-sc
 
 | ID   | Description                                | Status      | Updated    |
 | ---- | ------------------------------------------ | ----------- | ---------- |
-| 11.1 | FactoryModel placeholder & materials       | Not Started | 2025-10-16 |
-| 11.2 | ConveyorSystem + UV-scroll shader          | Not Started | 2025-10-16 |
-| 11.3 | TransferFX pool + event wiring             | Not Started | 2025-10-16 |
-| 11.4 | Boost emissive pulse                       | Not Started | 2025-10-16 |
-| 11.5 | Settings integration for performance profile | Not Started | 2025-10-16 |
-| 11.6 | Visual snapshot tests + perf scene         | Not Started | 2025-10-16 |
+| 11.1 | FactoryModel placeholder & materials       | Completed   | 2025-10-17 |
+| 11.2 | ConveyorSystem + UV-scroll shader          | Completed   | 2025-10-17 |
+| 11.3 | TransferFX pool + event wiring             | Completed   | 2025-10-17 |
+| 11.4 | Boost emissive pulse                       | Completed   | 2025-10-17 |
+| 11.5 | Settings integration for performance profile | Completed   | 2025-10-17 |
+| 11.6 | Visual snapshot tests + perf scene         | In Progress | 2025-10-17 |
 
 ## Acceptance Criteria
 
@@ -43,4 +43,8 @@ Factory visuals require art assets (sprites/meshes), cheap GPU techniques (UV-sc
 ### 2025-10-16
 
 - Created task file and linked design doc `DES010`.
+
+### 2025-10-17
+
+- Implemented factory activity tracking, conveyor animation, transfer FX, and boost pulse wired into the ECS; added profile-aware visuals and unit coverage for unload/refinery systems. Snapshot/perf scene follow-up remains open.
 

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -12,4 +12,4 @@
 | TASK008 | Visual Polish (Trails First)            | In Progress | 2025-10-17 |
 | TASK009 | Tests & CI                              | In Progress | 2025-10-16 |
 | TASK010 | Migration Helpers & Documentation       | Pending     | 2025-10-16 |
-| TASK011 | Factory Visuals                         | Pending     | 2025-10-16 |
+| TASK011 | Factory Visuals                         | In Progress | 2025-10-17 |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,25 +20,24 @@ export const App = ({ persistence }: AppProps) => {
   return (
     <ToastProvider>
       <div className="app">
-      <Canvas shadows camera={{ position: [0, 9, 22], fov: 52 }}>
-        <Scene />
-      </Canvas>
-      <div className="hud">
-        <div>Ore: {resources.ore.toFixed(1)}</div>
-        <div>Bars: {resources.bars.toFixed(1)}</div>
-        <div>Energy: {Math.round(resources.energy)}</div>
-        <div>Drones: {modules.droneBay}</div>
-        <button type="button" onClick={() => setSettingsOpen(true)} className="hud-button">
-          Settings
-        </button>
-      </div>
-      <UpgradePanel />
-      {settingsOpen ? (
-        <SettingsPanel onClose={() => setSettingsOpen(false)} persistence={persistence} />
-      ) : null}
+        <Canvas shadows camera={{ position: [0, 9, 22], fov: 52 }}>
+          <Scene />
+        </Canvas>
+        <div className="hud">
+          <div>Ore: {resources.ore.toFixed(1)}</div>
+          <div>Bars: {resources.bars.toFixed(1)}</div>
+          <div>Energy: {Math.round(resources.energy)}</div>
+          <div>Drones: {modules.droneBay}</div>
+          <button type="button" onClick={() => setSettingsOpen(true)} className="hud-button">
+            Settings
+          </button>
+        </div>
+        <UpgradePanel />
+        {settingsOpen ? (
+          <SettingsPanel onClose={() => setSettingsOpen(false)} persistence={persistence} />
+        ) : null}
       </div>
     </ToastProvider>
-    </div>
   );
 };
 

--- a/src/ecs/systems/droneAI.ts
+++ b/src/ecs/systems/droneAI.ts
@@ -4,12 +4,21 @@ import type { StoreApiType } from '@/state/store';
 
 const temp = new Vector3();
 
-const computeTravel = (drone: DroneEntity, destination: Vector3) => {
+const computeTravel = (
+  drone: DroneEntity,
+  destination: Vector3,
+  options?: { recordDockingFrom?: boolean },
+) => {
   const from = drone.position.clone();
   const to = destination.clone();
   const distance = from.distanceTo(to);
   const duration = Math.max(distance / Math.max(1, drone.speed), 0.1);
   drone.travel = { from, to, elapsed: 0, duration };
+  if (options?.recordDockingFrom) {
+    drone.lastDockingFrom = from.clone();
+  } else if (drone.state !== 'returning') {
+    drone.lastDockingFrom = null;
+  }
 };
 
 const findNearestAsteroid = (source: Vector3, asteroids: Iterable<AsteroidEntity>) => {
@@ -55,7 +64,7 @@ export const createDroneAISystem = (world: GameWorld, _store: StoreApiType) => {
         continue;
       }
       if (drone.state === 'returning' && !drone.travel) {
-        computeTravel(drone, factory.position);
+        computeTravel(drone, factory.position, { recordDockingFrom: true });
       }
     }
   };

--- a/src/ecs/systems/refinery.test.ts
+++ b/src/ecs/systems/refinery.test.ts
@@ -27,6 +27,9 @@ describe('ecs/systems/refinery', () => {
     const mirrorResources = mirrorStore.getState().resources;
     expect(systemResources.bars).toBeCloseTo(mirrorResources.bars, 5);
     expect(systemResources.ore).toBeCloseTo(mirrorResources.ore, 5);
+    expect(world.factory.activity.processing).toBeCloseTo(1, 5);
+    expect(world.factory.activity.boost).toBeGreaterThan(0.9);
+    expect(world.factory.activity.throughput).toBeGreaterThan(1);
   });
 
   it('ignores non-positive timesteps', () => {
@@ -37,5 +40,16 @@ describe('ecs/systems/refinery', () => {
     system(0);
     const after = store.getState().resources;
     expect(after).toEqual(before);
+  });
+
+  it('decays activity when no ore is processed', () => {
+    const world = createGameWorld({ asteroidCount: 0 });
+    const store = setupStore();
+    const system = createRefinerySystem(world, store);
+    system(0.5);
+    store.setState((state) => ({ resources: { ...state.resources, ore: 0 } }));
+    system(0.5);
+    expect(world.factory.activity.processing).toBeLessThan(1);
+    expect(world.factory.activity.boost).toBeLessThan(1);
   });
 });

--- a/src/ecs/systems/refinery.ts
+++ b/src/ecs/systems/refinery.ts
@@ -1,7 +1,23 @@
 import type { GameWorld } from '@/ecs/world';
-import type { StoreApiType } from '@/state/store';
+import { ORE_CONVERSION_PER_SECOND, ORE_PER_BAR, type StoreApiType } from '@/state/store';
 
-export const createRefinerySystem = (_world: GameWorld, store: StoreApiType) => (dt: number) => {
+const BOOST_THRESHOLD_MULTIPLIER = 1.2;
+const PROCESSING_DECAY_PER_SECOND = 0.9;
+const BOOST_DECAY_SECONDS = 1.5;
+
+export const createRefinerySystem = (world: GameWorld, store: StoreApiType) => (dt: number) => {
   if (dt <= 0) return;
-  store.getState().processRefinery(dt);
+  const stats = store.getState().processRefinery(dt);
+  const activity = world.factory.activity;
+  const orePerSecond = dt > 0 ? stats.oreConsumed / dt : 0;
+  const normalized = Math.min(1, orePerSecond / ORE_CONVERSION_PER_SECOND);
+  const decayedProcessing = Math.max(0, activity.processing - PROCESSING_DECAY_PER_SECOND * dt);
+  activity.processing = Math.min(1, Math.max(decayedProcessing, normalized));
+  const barsPerSecond = dt > 0 ? stats.barsProduced / dt : 0;
+  activity.throughput = Math.max(0, barsPerSecond);
+
+  const decayedBoost = Math.max(0, activity.boost - dt / BOOST_DECAY_SECONDS);
+  const baseBarsPerSecond = ORE_CONVERSION_PER_SECOND / ORE_PER_BAR;
+  const boostTrigger = barsPerSecond > baseBarsPerSecond * BOOST_THRESHOLD_MULTIPLIER;
+  activity.boost = boostTrigger ? 1 : decayedBoost;
 };

--- a/src/ecs/systems/unload.test.ts
+++ b/src/ecs/systems/unload.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { Vector3 } from 'three';
+import { createGameWorld, spawnDrone } from '@/ecs/world';
+import { createUnloadSystem } from '@/ecs/systems/unload';
+import { createStoreInstance } from '@/state/store';
+
+describe('ecs/systems/unload', () => {
+  it('emits transfer events and resets drone state', () => {
+    const world = createGameWorld({ asteroidCount: 0 });
+    const store = createStoreInstance();
+    const drone = spawnDrone(world);
+    drone.state = 'unloading';
+    drone.cargo = 20;
+    drone.lastDockingFrom = new Vector3(5, 0, 0);
+
+    const system = createUnloadSystem(world, store);
+    system(0.1);
+
+    expect(store.getState().resources.ore).toBeGreaterThan(0);
+    expect(drone.state).toBe('idle');
+    expect(drone.lastDockingFrom).toBeNull();
+    expect(world.events.transfers.length).toBe(1);
+    const [event] = world.events.transfers;
+    expect(event.amount).toBeCloseTo(20, 5);
+    expect(event.from.distanceTo(world.factory.position)).toBeGreaterThan(1);
+    expect(world.factory.activity.lastTransferAt).toBeGreaterThan(0);
+  });
+});

--- a/src/r3f/Factory.tsx
+++ b/src/r3f/Factory.tsx
@@ -1,18 +1,346 @@
+/* eslint-disable react/no-unknown-property */
+import { useFrame } from '@react-three/fiber';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { InstancedMesh, MeshStandardMaterial, PointLight } from 'three';
+import { CanvasTexture, Color, Matrix4, Quaternion, RepeatWrapping, Vector3 } from 'three';
 import { gameWorld } from '@/ecs/world';
+import { useStore, type PerformanceProfile } from '@/state/store';
 
-export const Factory = () => (
-  <group position={gameWorld.factory.position}>
-    <mesh castShadow receiveShadow>
-      <cylinderGeometry args={[2.2, 2.8, 1.4, 32]} />
-      <meshStandardMaterial color="#1f2937" metalness={0.6} roughness={0.35} />
-    </mesh>
-    <mesh position={[0, 1, 0]}>
-      <cylinderGeometry args={[1.4, 1.4, 0.8, 32]} />
-      <meshStandardMaterial color="#334155" emissive="#38bdf8" emissiveIntensity={0.5} />
-    </mesh>
-    <mesh position={[0, 1.6, 0]}>
-      <torusGeometry args={[1.8, 0.12, 12, 64]} />
-      <meshStandardMaterial color="#38bdf8" emissive="#0ea5e9" emissiveIntensity={0.7} />
-    </mesh>
-  </group>
-);
+interface BeltDefinition {
+  position: readonly [number, number, number];
+  scale: readonly [number, number, number];
+  direction: number;
+  pathFrom: Vector3;
+  pathTo: Vector3;
+}
+
+const BELTS: BeltDefinition[] = [
+  {
+    position: [0, 0.32, 1.6],
+    scale: [3.4, 0.18, 1],
+    direction: 1,
+    pathFrom: new Vector3(-1.7, 0.55, 1.4),
+    pathTo: new Vector3(0.4, 0.55, 0.5),
+  },
+  {
+    position: [0, 0.32, -1.6],
+    scale: [3.4, 0.18, 1],
+    direction: -1,
+    pathFrom: new Vector3(1.7, 0.55, -1.4),
+    pathTo: new Vector3(-0.4, 0.55, -0.5),
+  },
+];
+
+const PROFILE_CONFIG: Record<PerformanceProfile, {
+  itemCount: number;
+  transferLimit: number;
+  beltSpeed: number;
+  effectMultiplier: number;
+}> = {
+  low: { itemCount: 0, transferLimit: 0, beltSpeed: 0.55, effectMultiplier: 0.6 },
+  medium: { itemCount: 12, transferLimit: 12, beltSpeed: 0.85, effectMultiplier: 1 },
+  high: { itemCount: 24, transferLimit: 20, beltSpeed: 1.25, effectMultiplier: 1.3 },
+};
+
+const ITEM_POOL_SIZE = 36;
+const TRANSFER_POOL_SIZE = 28;
+const identityQuaternion = new Quaternion();
+const tempMatrix = new Matrix4();
+const tempVector = new Vector3();
+const fxScale = new Vector3(0.22, 0.22, 0.22);
+const itemScale = new Vector3(0.2, 0.2, 0.2);
+const fxColor = new Color('#38bdf8');
+
+type TransferState = {
+  active: boolean;
+  elapsed: number;
+  duration: number;
+  from: Vector3;
+  to: Vector3;
+  arcHeight: number;
+  amount: number;
+};
+
+type ItemState = {
+  pathIndex: number;
+  progress: number;
+  speed: number;
+  jitter: number;
+};
+
+const createConveyorTexture = () => {
+  if (typeof document === 'undefined') return null;
+  const size = 128;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const context = canvas.getContext('2d');
+  if (context) {
+    context.fillStyle = '#0f172a';
+    context.fillRect(0, 0, size, size);
+    context.fillStyle = '#1f2937';
+    for (let x = 0; x < size; x += 16) {
+      context.fillRect(x, 0, 8, size);
+    }
+    context.fillStyle = '#38bdf8';
+    context.globalAlpha = 0.2;
+    for (let x = 0; x < size; x += 32) {
+      context.fillRect(x, 0, 4, size);
+    }
+    context.globalAlpha = 1;
+  }
+  const texture = new CanvasTexture(canvas);
+  texture.wrapS = RepeatWrapping;
+  texture.wrapT = RepeatWrapping;
+  texture.repeat.set(4, 1);
+  return texture;
+};
+
+export const Factory = () => {
+  const performanceProfile = useStore((state) => state.settings.performanceProfile);
+  const beltTextures = useMemo(() => BELTS.map(() => createConveyorTexture()), []);
+  useEffect(() => () => {
+    beltTextures.forEach((texture) => texture?.dispose());
+  }, [beltTextures]);
+
+  const beltOffsets = useRef<number[]>(BELTS.map(() => 0));
+  const beltMaterials = useRef<Array<MeshStandardMaterial | null>>(BELTS.map(() => null));
+  const itemMeshRef = useRef<InstancedMesh>(null);
+  const transferMeshRef = useRef<InstancedMesh>(null);
+  const coreMaterialRef = useRef<MeshStandardMaterial>(null);
+  const ringMaterialRef = useRef<MeshStandardMaterial>(null);
+  const baseMaterialRef = useRef<MeshStandardMaterial>(null);
+  const boostLightRef = useRef<PointLight>(null);
+
+  const [initialItemStates] = useState<ItemState[]>(() =>
+    Array.from({ length: ITEM_POOL_SIZE }, (_, index) => ({
+      pathIndex: index % BELTS.length,
+      progress: Math.random(),
+      speed: 0.5 + Math.random() * 0.5,
+      jitter: (Math.random() - 0.5) * 0.3,
+    })),
+  );
+  const itemStates = useRef<ItemState[]>(initialItemStates);
+  const [initialTransferStates] = useState<TransferState[]>(() =>
+    Array.from({ length: TRANSFER_POOL_SIZE }, () => ({
+      active: false,
+      elapsed: 0,
+      duration: 0.65,
+      from: new Vector3(),
+      to: new Vector3(),
+      arcHeight: 0.5,
+      amount: 0,
+    })),
+  );
+  const transferStates = useRef<TransferState[]>(initialTransferStates);
+
+  useFrame((_, delta) => {
+    const { factory, events } = gameWorld;
+    const activity = factory.activity;
+    const profileConfig = PROFILE_CONFIG[performanceProfile];
+
+    const processing = activity.processing;
+    if (baseMaterialRef.current) {
+      baseMaterialRef.current.emissiveIntensity = 0.18 + processing * 0.35;
+    }
+    if (coreMaterialRef.current) {
+      coreMaterialRef.current.emissiveIntensity = 0.5 + processing * 0.9 + activity.boost * 0.6;
+    }
+    if (ringMaterialRef.current) {
+      ringMaterialRef.current.emissiveIntensity = 0.75 + activity.boost * 1.4;
+    }
+    beltMaterials.current.forEach((material) => {
+      if (!material) return;
+      material.emissiveIntensity = 0.12 + processing * 0.5;
+    });
+    if (boostLightRef.current) {
+      boostLightRef.current.intensity = 0.6 + activity.boost * 1.6;
+    }
+
+    beltTextures.forEach((texture, index) => {
+      if (!texture) return;
+      const direction = BELTS[index]?.direction ?? 1;
+      const baseSpeed = profileConfig.beltSpeed;
+      const speed = (0.25 + processing) * baseSpeed * direction;
+      const offset = beltOffsets.current[index] + delta * speed;
+      const wrapped = ((offset % 1) + 1) % 1;
+      beltOffsets.current[index] = wrapped;
+      texture.offset.x = wrapped;
+    });
+
+    const itemMesh = itemMeshRef.current;
+    if (itemMesh) {
+      const targetCount = profileConfig.itemCount;
+      if (targetCount <= 0) {
+        itemMesh.count = 0;
+        itemMesh.instanceMatrix.needsUpdate = true;
+      } else {
+        let count = 0;
+        const states = itemStates.current;
+        const speedFactor = 0.5 + processing * 1.4;
+        for (let i = 0; i < targetCount && i < states.length; i += 1) {
+          const state = states[i];
+          state.progress = (state.progress + delta * state.speed * speedFactor) % 1;
+          const path = BELTS[state.pathIndex % BELTS.length];
+          tempVector.copy(path.pathFrom).lerp(path.pathTo, state.progress);
+          tempVector.y += state.jitter * 0.08;
+          tempMatrix.compose(tempVector, identityQuaternion, itemScale);
+          itemMesh.setMatrixAt(count, tempMatrix);
+          count += 1;
+        }
+        itemMesh.count = count;
+        itemMesh.instanceMatrix.needsUpdate = count > 0;
+      }
+    }
+
+    const transferMesh = transferMeshRef.current;
+    const queue = events.transfers;
+    if (transferMesh) {
+      if (profileConfig.transferLimit <= 0) {
+        queue.length = 0;
+        transferStates.current.forEach((state) => {
+          state.active = false;
+          state.elapsed = 0;
+        });
+        transferMesh.count = 0;
+        transferMesh.instanceMatrix.needsUpdate = true;
+      } else {
+        let spawnBudget = profileConfig.transferLimit;
+        while (queue.length > 0 && spawnBudget > 0) {
+          const event = queue.shift();
+          if (!event) break;
+          spawnBudget -= 1;
+          const slot = transferStates.current.find((state) => !state.active);
+          if (!slot) {
+            queue.unshift(event);
+            break;
+          }
+          slot.active = true;
+          slot.elapsed = 0;
+          slot.duration = event.duration;
+          slot.from.copy(event.from);
+          slot.to.copy(event.to);
+          slot.amount = event.amount;
+          slot.arcHeight = 0.4 + Math.min(1, event.amount / 80) * 0.5 * profileConfig.effectMultiplier;
+        }
+        if (queue.length > TRANSFER_POOL_SIZE) {
+          queue.splice(0, queue.length - TRANSFER_POOL_SIZE);
+        }
+        let count = 0;
+        for (const state of transferStates.current) {
+          if (!state.active) continue;
+          state.elapsed += delta;
+          const progress = state.duration > 0 ? state.elapsed / state.duration : 1;
+          if (progress >= 1) {
+            state.active = false;
+            continue;
+          }
+          const eased = progress * (2 - progress);
+          tempVector.copy(state.from).lerp(state.to, eased);
+          tempVector.y += Math.sin(Math.PI * eased) * state.arcHeight;
+          tempMatrix.compose(tempVector, identityQuaternion, fxScale);
+          transferMesh.setMatrixAt(count, tempMatrix);
+          const brightness = 0.55 + activity.boost * 0.4 + Math.min(0.4, state.amount / 140);
+          fxColor.setHSL(0.53, 0.85, Math.min(0.8, brightness));
+          transferMesh.setColorAt?.(count, fxColor);
+          count += 1;
+        }
+        transferMesh.count = count;
+        transferMesh.instanceMatrix.needsUpdate = count > 0;
+        if (transferMesh.instanceColor) {
+          transferMesh.instanceColor.needsUpdate = count > 0;
+        }
+      }
+    } else {
+      queue.length = 0;
+    }
+  });
+
+  const { factory } = gameWorld;
+
+  return (
+    <group position={factory.position} quaternion={factory.orientation}>
+      <mesh castShadow receiveShadow>
+        <cylinderGeometry args={[2.2, 2.8, 1.2, 32]} />
+        <meshStandardMaterial
+          ref={baseMaterialRef}
+          color="#1f2937"
+          metalness={0.55}
+          roughness={0.4}
+          emissive="#0f172a"
+          emissiveIntensity={0.22}
+        />
+      </mesh>
+      <mesh position={[0, 0.6, 0]} castShadow receiveShadow>
+        <cylinderGeometry args={[1.6, 1.6, 1, 32]} />
+        <meshStandardMaterial
+          ref={coreMaterialRef}
+          color="#1e293b"
+          metalness={0.65}
+          roughness={0.3}
+          emissive="#38bdf8"
+          emissiveIntensity={0.6}
+        />
+      </mesh>
+      <mesh position={[0, 1.5, 0]} castShadow receiveShadow>
+        <torusGeometry args={[1.9, 0.12, 18, 64]} />
+        <meshStandardMaterial
+          ref={ringMaterialRef}
+          color="#38bdf8"
+          emissive="#0ea5e9"
+          emissiveIntensity={0.8}
+          metalness={0.45}
+          roughness={0.22}
+        />
+      </mesh>
+      <mesh position={[0, 0.2, 0]} receiveShadow>
+        <boxGeometry args={[3.4, 0.16, 3.4]} />
+        <meshStandardMaterial color="#111827" metalness={0.2} roughness={0.65} />
+      </mesh>
+      {BELTS.map((belt, index) => (
+        <mesh
+          key={`belt-${index}`}
+          position={belt.position}
+          rotation={[0, index === 0 ? 0 : Math.PI, 0]}
+          castShadow
+          receiveShadow
+        >
+          <boxGeometry args={belt.scale} />
+          <meshStandardMaterial
+            ref={(material) => {
+              beltMaterials.current[index] = material;
+            }}
+            color="#0f172a"
+            metalness={0.25}
+            roughness={0.5}
+            emissive="#155e75"
+            emissiveIntensity={0.18}
+            map={beltTextures[index] ?? undefined}
+          />
+        </mesh>
+      ))}
+      <instancedMesh ref={itemMeshRef} args={[undefined as never, undefined as never, ITEM_POOL_SIZE]} castShadow>
+        <boxGeometry args={[0.28, 0.18, 0.28]} />
+        <meshStandardMaterial color="#f59e0b" emissive="#fbbf24" emissiveIntensity={0.4} roughness={0.4} />
+      </instancedMesh>
+      <instancedMesh
+        ref={transferMeshRef}
+        args={[undefined as never, undefined as never, TRANSFER_POOL_SIZE]}
+        castShadow
+      >
+        <sphereGeometry args={[0.16, 12, 12]} />
+        <meshStandardMaterial
+          color="#38bdf8"
+          emissive="#0ea5e9"
+          emissiveIntensity={0.9}
+          roughness={0.25}
+          metalness={0.2}
+          vertexColors
+          transparent
+          opacity={0.9}
+        />
+      </instancedMesh>
+      <pointLight ref={boostLightRef} position={[0, 2.6, 0]} color="#38bdf8" intensity={0.8} distance={10} decay={2} />
+    </group>
+  );
+};

--- a/src/state/persistence.test.ts
+++ b/src/state/persistence.test.ts
@@ -30,6 +30,7 @@ describe('state/persistence', () => {
         autosaveInterval: 10,
         offlineCapHours: 12,
         notation: 'standard' as const,
+        performanceProfile: 'medium' as const,
       },
       rngSeed: 123456789,
     };

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -60,12 +60,14 @@ describe('state/store', () => {
       notation: 'engineering',
       offlineCapHours: -4,
       showTrails: false,
+      performanceProfile: 'high',
     });
     const afterUpdate = store.getState();
     expect(afterUpdate.settings.autosaveInterval).toBe(33);
     expect(afterUpdate.settings.notation).toBe('engineering');
     expect(afterUpdate.settings.offlineCapHours).toBe(0);
     expect(afterUpdate.settings.showTrails).toBe(false);
+    expect(afterUpdate.settings.performanceProfile).toBe('high');
 
     const snapshot = serializeStore(store.getState());
     expect(snapshot.settings.autosaveInterval).toBe(33);
@@ -82,6 +84,7 @@ describe('state/store', () => {
     const imported = fresh.getState();
     expect(imported.settings.autosaveInterval).toBe(33);
     expect(imported.settings.showTrails).toBe(false);
+    expect(imported.settings.performanceProfile).toBe('high');
     expect(imported.resources.ore).toBe(snapshot.resources.ore);
   });
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -10,14 +10,16 @@ const SAVE_VERSION = '0.1.0';
 const GROWTH = 1.15;
 const PRESTIGE_THRESHOLD = 5_000;
 const BASE_REFINERY_RATE = 1;
-const ORE_PER_BAR = 10;
-const ORE_CONVERSION_PER_SECOND = 10;
+export const ORE_PER_BAR = 10;
+export const ORE_CONVERSION_PER_SECOND = 10;
 const BASE_STORAGE = 400;
 const STORAGE_PER_LEVEL = 100;
 const BASE_ENERGY_CAP = 100;
 const ENERGY_PER_SOLAR = 25;
 const SOLAR_BASE_GEN = 5;
 export const DRONE_ENERGY_COST = 1.2;
+
+export type PerformanceProfile = 'low' | 'medium' | 'high';
 
 const initialSettings: StoreSettings = {
   autosaveEnabled: true,
@@ -26,6 +28,7 @@ const initialSettings: StoreSettings = {
   notation: 'standard',
   throttleFloor: 0.25,
   showTrails: true,
+  performanceProfile: 'medium',
 };
 
 export const saveVersion = SAVE_VERSION;
@@ -82,6 +85,7 @@ export interface StoreSettings {
   notation: NotationMode;
   throttleFloor: number;
   showTrails: boolean;
+  performanceProfile: PerformanceProfile;
 }
 
 export interface RefineryStats {
@@ -221,6 +225,13 @@ const normalizeSave = (snapshot?: Partial<SaveMeta>): SaveMeta => ({
 const normalizeNotation = (notation: unknown): NotationMode =>
   notation === 'engineering' ? 'engineering' : 'standard';
 
+const normalizePerformanceProfile = (profile: unknown): PerformanceProfile => {
+  if (profile === 'low' || profile === 'high') {
+    return profile;
+  }
+  return 'medium';
+};
+
 const normalizeSettings = (snapshot?: Partial<StoreSettings>): StoreSettings => ({
   autosaveEnabled:
     typeof snapshot?.autosaveEnabled === 'boolean'
@@ -241,6 +252,7 @@ const normalizeSettings = (snapshot?: Partial<StoreSettings>): StoreSettings => 
   ),
   showTrails:
     typeof snapshot?.showTrails === 'boolean' ? snapshot.showTrails : initialSettings.showTrails,
+  performanceProfile: normalizePerformanceProfile(snapshot?.performanceProfile),
 });
 
 const normalizeSnapshot = (snapshot: Partial<StoreSnapshot>): StoreSnapshot => ({

--- a/src/ui/Settings.test.tsx
+++ b/src/ui/Settings.test.tsx
@@ -44,6 +44,7 @@ describe('ui/Settings', () => {
         notation: 'standard',
         throttleFloor: 0.25,
         showTrails: true,
+        performanceProfile: 'medium',
       },
       save: { ...state.save, lastSave: 1_700_000_000_000 },
     }));
@@ -93,6 +94,16 @@ describe('ui/Settings', () => {
     expect(toggle.checked).toBe(true);
     fireEvent.click(toggle);
     expect(storeApi.getState().settings.showTrails).toBe(false);
+  });
+
+  it('changes factory performance profile', () => {
+    const persistence = createPersistenceMock();
+    render(<SettingsPanel onClose={() => undefined} persistence={persistence} />);
+
+    const select = screen.getByLabelText<HTMLSelectElement>(/factory performance profile/i);
+    expect(select.value).toBe('medium');
+    fireEvent.change(select, { target: { value: 'high' } });
+    expect(storeApi.getState().settings.performanceProfile).toBe('high');
   });
 
   it('invokes persistence export workflow when exporting', () => {

--- a/src/ui/ToastProvider.tsx
+++ b/src/ui/ToastProvider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import Toast from './Toast';
 


### PR DESCRIPTION
## Summary
- track factory activity state and transfer events across the ECS to drive visual feedback and boost telemetry
- rebuild the Factory renderer with animated conveyors, instanced ore items, transfer FX, and boost lighting that respond to the selected performance profile
- add a factory performance profile setting (store + Settings UI) along with new tests covering unload/refinery visuals and the UI toggle

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npx prettier --check . (reports existing formatting warnings)

------
https://chatgpt.com/codex/tasks/task_e_68f104f3aa00832abc4112ea44bd191f