### PR TITLE
feat: persist per-drone flight state

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Saves are JSON snapshots stored under the `space-factory-save` key in `localStor
 - `settings` — user-configurable options (autosave, offline cap, notation, throttleFloor, showTrails)
 - `save` — metadata (lastSave timestamp and `version` string)
 - `rngSeed` — optional numeric seed for deterministic RNG
+- `droneFlights` — optional array describing active drone trips (target asteroid, path seed, travel progress)
 
 Versioning and migration strategy:
 

--- a/memory/activeContext.md
+++ b/memory/activeContext.md
@@ -2,18 +2,17 @@
 
 ## Current Focus
 
-Implement factory visual upgrades (TASK011) including conveyors, transfer FX, and performance profiles while keeping persistence/settings docs aligned with the shipped implementation.
+Implement per-drone asteroid targeting variation and seeded flight offsets (TASK012), including persistence of in-progress flights across saves.
 
 ## Recent Changes
 
 - Finalized spec/persistence backlog items for TASK002, documenting the live manager wiring and Settings defaults.
 - Added `settings.showTrails` persistence, Settings toggle, and new tests covering normalization/export/import paths.
 - Implemented `TrailBuffer` + `DroneTrails` to render fading path lines behind drones with a single draw call.
-
 - Implemented migration helpers in `src/state/migrations.ts` and updated the README with save format / migration strategy guidance. Legacy snapshots are normalized during load/import to avoid breaking player progress.
 
 ## Next Steps
 
-- Validate runtime performance of the new trails on low-spec profiles and provide screenshots for design review.
-- Ship factory/scanner visual polish follow-ups and related Settings toggles, starting with TASK011, and close out remaining snapshot/perf coverage.
-- Plan HUD indicators for energy throttling/battery state once visual polish baseline ships.
+- Monitor runtime performance/visual impact of the new per-drone flights and adjust offset ranges if needed.
+- Coordinate follow-up polish for Task011 and remaining visual backlog items now that flight persistence landed.
+- Document migration rollout guidance for QA and confirm legacy saves resume in-flight drones without regression reports.

--- a/memory/progress.md
+++ b/memory/progress.md
@@ -18,6 +18,9 @@
 
 - Upgraded factory visuals with animated conveyors, transfer FX, boost pulses, and a settings-driven performance profile backed by ECS activity signals (TASK011).
 
+- Kicked off TASK012 to add per-drone target variation, seeded path offsets, and save/load persistence for active flights; requirements drafted and implementation plan captured in the task log.
+- Completed TASK012 with weighted targeting, seeded bezier travel, persisted `droneFlights`, README updates, and unit/integration coverage ensuring mid-flight saves restore correctly.
+
 ## Open Items
 
 - Track UI follow-up for surfacing per-drone battery levels and throttle warnings in the HUD.

--- a/memory/requirements.md
+++ b/memory/requirements.md
@@ -59,3 +59,15 @@ WHEN refinery throughput exceeds the baseline by 20% or more, THE SYSTEM SHALL t
 ## RQ-015 Performance Profiles
 
 WHEN the player selects a factory performance profile in Settings, THE SYSTEM SHALL adjust visual effect density to match the profile within the next rendered frame and persist the choice across saves. [Acceptance: Unit tests cover settings normalization/export, and manual verification confirms profiles toggle effect density.]
+
+## RQ-016 Per-Drone Target Selection
+
+WHEN an idle drone seeks a mining target while multiple asteroids are available, THE SYSTEM SHALL choose among the nearby asteroids using deterministic weighted randomization so that simultaneous assignments distribute drones instead of converging on a single rock. [Acceptance: Unit tests simulate repeated assignments and assert the chosen asteroid IDs vary when multiple options exist.]
+
+## RQ-017 Deterministic Flight Offsets
+
+WHEN a drone begins travel, THE SYSTEM SHALL generate a seeded path offset that perturbs the waypoint curve without changing its endpoints, ensuring drones with identical seeds reproduce the same motion. [Acceptance: Unit tests cover offset determinism for fixed seeds and confirm path endpoints remain stable.]
+
+## RQ-018 Flight Persistence
+
+WHEN the player saves or reloads while drones are mid-flight, THE SYSTEM SHALL serialize and restore each flight's target, seeded offset, and progress so that drones resume the exact trajectory after load. [Acceptance: Integration test saves a mid-flight snapshot, reloads it, and verifies flight state resumes with matching progress and seed.]

--- a/memory/tasks/TASK012-drone-asteroid-variation.md
+++ b/memory/tasks/TASK012-drone-asteroid-variation.md
@@ -1,24 +1,50 @@
 # TASK012 - Per-Drone Asteroid Targeting & Path Variation
 
-**Status:** Pending
+**Status:** Completed
 **Added:** 2025-10-16
-**Updated:** 2025-10-16
+**Updated:** 2025-10-17
 
 ## Original Request
 
 Introduce per-drone targeting variation and minor path offsets so drones fly differently to similar destinations. Preserve in-progress flights across saves.
 
+## Thought Process
+
+- The requirements emphasize per-drone variation (target selection, path offsets) and durability across persistence boundaries.
+- We need store-level state so that save snapshots can capture in-flight metadata without relying on runtime-only ECS data.
+- Travel offsets should be lightweight (single seeded curve control) to avoid heavy pathfinding overhead while staying deterministic.
+
 ## Implementation Plan
 
 Subtasks:
-1. Add `DroneFlightState` type and storage inside `ecs` or `state` where drone entities are represented.
-2. Implement `assignDroneTarget(droneId, asteroids)` in `ecs/systems/droneAI.ts` that chooses among nearby asteroids using weighted randomization and records `targetAsteroidId` and `pathSeed`.
-3. Implement `computeWaypointWithOffset(baseWaypoint, seed, index)` in `ecs/systems/travel.ts` or `lib/rng.ts` utilities for deterministic per-flight offsets.
-4. Ensure travel system uses offsets when calculating trajectories.
-5. Persist per-flight state in the existing save snapshot: include `droneFlights?: DroneFlightState[]` in saved snapshot.
-6. Add unit tests: assignDroneTarget, computeWaypointWithOffset; add integration test for in-flight persistence.
-7. Update migration notes and bump save version if necessary.
-8. Manual test: run with several drones/asteroids and observe variety; save & reload mid-flight and confirm identical continuation.
+1. Extend store snapshot/schema with `DroneFlightState` plus helpers for serializing vector data; bump save version and migrations.
+2. Implement `assignDroneTarget` with weighted random selection over nearby asteroids, generating and recording per-flight seeds.
+3. Add `computeWaypointWithOffset` utility for deterministic control-point offsets; update travel system to use seeded bezier curves.
+4. Synchronize ECS drones with persisted flight records on load and when travel progresses or completes.
+5. Write unit tests for targeting/offset helpers and an integration test that saves mid-flight and reloads the snapshot.
+
+## Progress Tracking
+
+**Overall Status:** Completed - 100%
+
+### Subtasks
+
+| ID | Description | Status | Updated | Notes |
+| -- | ----------- | ------ | ------- | ----- |
+| 1 | Store schema + migrations | Completed | 2025-10-17 | Added `droneFlights` snapshot data and migration to seed empty arrays. |
+| 2 | Target assignment variation | Completed | 2025-10-17 | Implemented weighted per-drone targeting with seeded flight state. |
+| 3 | Seeded path offsets | Completed | 2025-10-17 | Added bezier control offsets derived from deterministic seeds. |
+| 4 | ECS sync & persistence | Completed | 2025-10-17 | Synced drones with persisted flights and curved travel paths. |
+| 5 | Tests & validation | Completed | 2025-10-17 | Added unit + integration coverage and updated README/tests. |
+
+## Progress Log
+
+### 2025-10-17
+
+- Captured requirements (RQ-016 – RQ-018) and outlined implementation subtasks spanning store persistence, flight assignment, path offsets, ECS syncing, and tests.
+- Implemented new `droneFlights` snapshot schema with migrations and serialization helpers; persisted in-progress travel and cleared on completion.
+- Added weighted target assignment, seeded offset curves, and ECS synchronization to restore/save flights with deterministic bezier travel.
+- Delivered README/persistence documentation updates plus unit, integration, and e2e test fixes; lint/typecheck/test suites all passing.
 
 ## Acceptance Tests
 

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -13,4 +13,4 @@
 | TASK009 | Tests & CI                              | In Progress | 2025-10-16 |
 | TASK010 | Migration Helpers & Documentation       | Pending     | 2025-10-16 |
 | TASK011 | Factory Visuals                         | In Progress | 2025-10-17 |
-| TASK012 | Drone Asteroid Targeting Variation      | Pending     | 2025-10-16 |
+| TASK012 | Drone Asteroid Targeting Variation      | Completed   | 2025-10-17 |

--- a/src/ecs/flights.ts
+++ b/src/ecs/flights.ts
@@ -1,0 +1,40 @@
+import { Vector3 } from 'three';
+import type { TravelData } from '@/ecs/world';
+import type { TravelSnapshot, VectorTuple } from '@/state/store';
+
+export const vectorToTuple = (vector: Vector3): VectorTuple => [vector.x, vector.y, vector.z];
+
+export const tupleToVector = (tuple: VectorTuple): Vector3 => new Vector3(tuple[0], tuple[1], tuple[2]);
+
+export const travelToSnapshot = (travel: TravelData): TravelSnapshot => ({
+  from: vectorToTuple(travel.from),
+  to: vectorToTuple(travel.to),
+  elapsed: travel.elapsed,
+  duration: travel.duration,
+  control: travel.control ? vectorToTuple(travel.control) : undefined,
+});
+
+export const snapshotToTravel = (snapshot: TravelSnapshot): TravelData => ({
+  from: tupleToVector(snapshot.from),
+  to: tupleToVector(snapshot.to),
+  elapsed: snapshot.elapsed,
+  duration: snapshot.duration,
+  control: snapshot.control ? tupleToVector(snapshot.control) : undefined,
+});
+
+export const computeTravelPosition = (travel: TravelData, out: Vector3 = new Vector3()): Vector3 => {
+  const duration = travel.duration > 0 ? travel.duration : 1;
+  const t = Math.max(0, Math.min(1, travel.elapsed / duration));
+  if (travel.control) {
+    const oneMinusT = 1 - t;
+    const a = oneMinusT * oneMinusT;
+    const b = 2 * oneMinusT * t;
+    const c = t * t;
+    return out
+      .copy(travel.from)
+      .multiplyScalar(a)
+      .addScaledVector(travel.control, b)
+      .addScaledVector(travel.to, c);
+  }
+  return out.lerpVectors(travel.from, travel.to, t);
+};

--- a/src/ecs/systems/droneAI.test.ts
+++ b/src/ecs/systems/droneAI.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { Vector3 } from 'three';
+import { assignDroneTarget } from '@/ecs/systems/droneAI';
+import { computeWaypointWithOffset } from '@/ecs/systems/travel';
+import type { AsteroidEntity, DroneEntity } from '@/ecs/world';
+import { createRng } from '@/lib/rng';
+
+const createAsteroid = (id: string, position: Vector3, oreRemaining = 100): AsteroidEntity => ({
+  id,
+  kind: 'asteroid',
+  position,
+  oreRemaining,
+  richness: 1,
+  radius: 1,
+  rotation: 0,
+  spin: 0,
+  colorBias: 1,
+});
+
+const createDrone = (position: Vector3): DroneEntity => ({
+  id: 'drone-test',
+  kind: 'drone',
+  position: position.clone(),
+  state: 'idle',
+  targetId: null,
+  cargo: 0,
+  capacity: 40,
+  speed: 14,
+  miningRate: 6,
+  travel: null,
+  miningAccumulator: 0,
+  battery: 24,
+  maxBattery: 24,
+  charging: false,
+  lastDockingFrom: null,
+  flightSeed: null,
+});
+
+describe('assignDroneTarget', () => {
+  it('distributes targets across nearby asteroids using randomness', () => {
+    const drone = createDrone(new Vector3(0, 0, 0));
+    const asteroids = [
+      createAsteroid('asteroid-a', new Vector3(5, 0, 0)),
+      createAsteroid('asteroid-b', new Vector3(6, 0, 1)),
+      createAsteroid('asteroid-c', new Vector3(12, 0, -2)),
+    ];
+    const rng = createRng(42);
+    const selections = new Set<string>();
+    for (let i = 0; i < 8; i += 1) {
+      const result = assignDroneTarget(drone, asteroids, rng);
+      expect(result).not.toBeNull();
+      selections.add(result!.target.id);
+    }
+    expect(selections.size).toBeGreaterThan(1);
+  });
+});
+
+describe('computeWaypointWithOffset', () => {
+  it('produces deterministic offsets for identical seeds and indices', () => {
+    const base = new Vector3(10, 1, -3);
+    const first = computeWaypointWithOffset(base, 12345, 0);
+    const second = computeWaypointWithOffset(base, 12345, 0);
+    expect(first.equals(second)).toBe(true);
+    expect(base.equals(new Vector3(10, 1, -3))).toBe(true);
+    const different = computeWaypointWithOffset(base, 12345, 1);
+    expect(first.equals(different)).toBe(false);
+  });
+});

--- a/src/ecs/systems/droneAI.ts
+++ b/src/ecs/systems/droneAI.ts
@@ -1,70 +1,223 @@
 import { Vector3 } from 'three';
-import type { AsteroidEntity, DroneEntity, GameWorld } from '@/ecs/world';
-import type { StoreApiType } from '@/state/store';
+import type { AsteroidEntity, DroneEntity, GameWorld, TravelData } from '@/ecs/world';
+import { computeTravelPosition, snapshotToTravel, travelToSnapshot } from '@/ecs/flights';
+import type { DroneFlightPhase, DroneFlightState, StoreApiType } from '@/state/store';
+import type { RandomSource } from '@/lib/rng';
+import { computeWaypointWithOffset } from '@/ecs/systems/travel';
 
-const temp = new Vector3();
+const nearestTemp = new Vector3();
+const midPoint = new Vector3();
+const direction = new Vector3();
+const offset = new Vector3();
 
-const computeTravel = (
+const NEARBY_LIMIT = 4;
+const MAX_OFFSET_DISTANCE = 3;
+const EPSILON = 1e-4;
+
+interface TargetCandidate {
+  asteroid: AsteroidEntity;
+  distance: number;
+  weight: number;
+}
+
+interface AssignmentResult {
+  target: AsteroidEntity;
+  pathSeed: number;
+}
+
+const toWeight = (distance: number) => 1 / Math.max(distance, 1);
+
+const buildCandidates = (
+  drone: DroneEntity,
+  asteroids: Iterable<AsteroidEntity>,
+): TargetCandidate[] => {
+  const candidates: TargetCandidate[] = [];
+  for (const asteroid of asteroids) {
+    if (asteroid.oreRemaining <= 0) continue;
+    const distance = nearestTemp.copy(asteroid.position).distanceTo(drone.position);
+    candidates.push({ asteroid, distance, weight: 0 });
+  }
+  candidates.sort((a, b) => a.distance - b.distance);
+  return candidates.slice(0, Math.min(NEARBY_LIMIT, candidates.length));
+};
+
+export const assignDroneTarget = (
+  drone: DroneEntity,
+  asteroids: Iterable<AsteroidEntity>,
+  rng: RandomSource,
+): AssignmentResult | null => {
+  const candidates = buildCandidates(drone, asteroids);
+  if (candidates.length === 0) {
+    return null;
+  }
+  let totalWeight = 0;
+  for (const candidate of candidates) {
+    candidate.weight = toWeight(candidate.distance);
+    totalWeight += candidate.weight;
+  }
+  const roll = rng.next() * (totalWeight || 1);
+  let accumulated = 0;
+  let chosen = candidates[candidates.length - 1];
+  for (const candidate of candidates) {
+    accumulated += candidate.weight;
+    if (roll <= accumulated) {
+      chosen = candidate;
+      break;
+    }
+  }
+  const seed = Math.max(1, Math.floor(rng.next() * 0xffffffff));
+  return { target: chosen.asteroid, pathSeed: seed };
+};
+
+const startTravel = (
   drone: DroneEntity,
   destination: Vector3,
+  phase: DroneFlightPhase,
+  store: StoreApiType,
   options?: { recordDockingFrom?: boolean },
 ) => {
   const from = drone.position.clone();
   const to = destination.clone();
   const distance = from.distanceTo(to);
   const duration = Math.max(distance / Math.max(1, drone.speed), 0.1);
-  drone.travel = { from, to, elapsed: 0, duration };
-  if (options?.recordDockingFrom) {
-    drone.lastDockingFrom = from.clone();
-  } else if (drone.state !== 'returning') {
-    drone.lastDockingFrom = null;
-  }
-};
+  const travel: TravelData = { from, to, elapsed: 0, duration };
+  const pathSeed = drone.flightSeed ?? 1;
+  drone.flightSeed = pathSeed;
 
-const findNearestAsteroid = (source: Vector3, asteroids: Iterable<AsteroidEntity>) => {
-  let nearest: AsteroidEntity | null = null;
-  let closest = Number.POSITIVE_INFINITY;
-  for (const asteroid of asteroids) {
-    if (asteroid.oreRemaining <= 0) continue;
-    const distance = temp.copy(asteroid.position).distanceTo(source);
-    if (distance < closest) {
-      closest = distance;
-      nearest = asteroid;
+  if (pathSeed) {
+    midPoint.copy(from).lerp(to, 0.5);
+    offset
+      .copy(computeWaypointWithOffset(midPoint, pathSeed, 0))
+      .sub(midPoint);
+    direction.copy(to).sub(from);
+    const magnitudeSq = direction.lengthSq();
+    if (magnitudeSq > EPSILON) {
+      direction.normalize();
+      const parallel = direction.dot(offset);
+      offset.addScaledVector(direction, -parallel);
+      if (offset.lengthSq() > EPSILON) {
+        offset.clampLength(0, Math.max(0.5, Math.min(MAX_OFFSET_DISTANCE, distance * 0.25)));
+        travel.control = midPoint.clone().add(offset);
+      }
     }
   }
-  return nearest;
+
+  drone.travel = travel;
+  drone.state = phase;
+  if (phase === 'returning') {
+    drone.targetId = null;
+  }
+  if (options?.recordDockingFrom) {
+    drone.lastDockingFrom = from.clone();
+  } else if (phase !== 'returning') {
+    drone.lastDockingFrom = null;
+  }
+
+  const targetAsteroidId = phase === 'toAsteroid' ? drone.targetId : null;
+  store.getState().recordDroneFlight({
+    droneId: drone.id,
+    state: phase,
+    targetAsteroidId,
+    pathSeed,
+    travel: travelToSnapshot(travel),
+  });
 };
 
-export const createDroneAISystem = (world: GameWorld, _store: StoreApiType) => {
-  const { droneQuery, asteroidQuery, factory } = world;
+const synchronizeDroneFlight = (
+  drone: DroneEntity,
+  flight: DroneFlightState,
+  world: GameWorld,
+  store: StoreApiType,
+) => {
+  if (flight.state === 'toAsteroid') {
+    if (!flight.targetAsteroidId) {
+      store.getState().clearDroneFlight(flight.droneId);
+      return;
+    }
+    const target = world.asteroidQuery.entities.find((asteroid) => asteroid.id === flight.targetAsteroidId);
+    if (!target || target.oreRemaining <= 0) {
+      store.getState().clearDroneFlight(flight.droneId);
+      drone.state = 'idle';
+      drone.targetId = null;
+      drone.travel = null;
+      drone.flightSeed = null;
+      return;
+    }
+  }
+
+  const needsUpdate =
+    drone.state !== flight.state ||
+    drone.flightSeed !== flight.pathSeed ||
+    !drone.travel ||
+    Math.abs(drone.travel.elapsed - flight.travel.elapsed) > 1e-4;
+
+  if (!needsUpdate) {
+    return;
+  }
+
+  const travel = snapshotToTravel(flight.travel);
+  drone.state = flight.state;
+  drone.flightSeed = flight.pathSeed;
+  drone.targetId = flight.state === 'toAsteroid' ? flight.targetAsteroidId : null;
+  drone.travel = travel;
+  if (flight.state === 'returning') {
+    drone.lastDockingFrom = travel.from.clone();
+  }
+  computeTravelPosition(travel, drone.position);
+};
+
+export const createDroneAISystem = (world: GameWorld, store: StoreApiType) => {
+  const { droneQuery, asteroidQuery, factory, rng } = world;
   return (_dt: number) => {
+    const flights = store.getState().droneFlights;
+    const flightMap = new Map<string, DroneFlightState>();
+    for (const flight of flights) {
+      flightMap.set(flight.droneId, flight);
+    }
+
     for (const drone of droneQuery) {
+      const storedFlight = flightMap.get(drone.id);
+      if (storedFlight) {
+        synchronizeDroneFlight(drone, storedFlight, world, store);
+      }
+
       if (drone.state === 'idle') {
-        const target = findNearestAsteroid(drone.position, asteroidQuery);
-        if (target) {
-          drone.targetId = target.id;
-          drone.state = 'toAsteroid';
-          computeTravel(drone, target.position);
+        drone.flightSeed = null;
+        const assignment = assignDroneTarget(drone, asteroidQuery, rng);
+        if (assignment) {
+          drone.targetId = assignment.target.id;
+          drone.flightSeed = assignment.pathSeed;
+          startTravel(drone, assignment.target.position, 'toAsteroid', store);
+        } else {
+          store.getState().clearDroneFlight(drone.id);
         }
         continue;
       }
+
       if (drone.state === 'toAsteroid') {
         const target = asteroidQuery.entities.find((asteroid) => asteroid.id === drone.targetId);
         if (!target || target.oreRemaining <= 0) {
+          store.getState().clearDroneFlight(drone.id);
           drone.state = 'idle';
           drone.targetId = null;
           drone.travel = null;
+          drone.flightSeed = null;
         }
         continue;
       }
+
       if (drone.state === 'unloading' && drone.cargo <= 0.01) {
+        store.getState().clearDroneFlight(drone.id);
         drone.state = 'idle';
         drone.targetId = null;
         drone.travel = null;
+        drone.flightSeed = null;
         continue;
       }
+
       if (drone.state === 'returning' && !drone.travel) {
-        computeTravel(drone, factory.position, { recordDockingFrom: true });
+        drone.flightSeed = Math.max(1, Math.floor(rng.next() * 0xffffffff));
+        startTravel(drone, factory.position, 'returning', store, { recordDockingFrom: true });
       }
     }
   };

--- a/src/ecs/systems/droneFlightPersistence.test.ts
+++ b/src/ecs/systems/droneFlightPersistence.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { createGameWorld, spawnDrone, type TravelData } from '@/ecs/world';
+import { createStoreInstance, serializeStore } from '@/state/store';
+import { createDroneAISystem } from '@/ecs/systems/droneAI';
+import { createTravelSystem } from '@/ecs/systems/travel';
+import { computeTravelPosition, snapshotToTravel } from '@/ecs/flights';
+import { createRng } from '@/lib/rng';
+
+describe('drone flight persistence', () => {
+  it('restores in-progress flights from serialized snapshots', () => {
+    const world = createGameWorld({ asteroidCount: 3, rng: createRng(123456) });
+    const store = createStoreInstance();
+    const drone = spawnDrone(world);
+    drone.position.copy(world.factory.position);
+
+    const aiSystem = createDroneAISystem(world, store);
+    const travelSystem = createTravelSystem(world, store);
+
+    aiSystem(0);
+    expect(store.getState().droneFlights).toHaveLength(1);
+
+    travelSystem(0.4);
+    const progressedFlight = store.getState().droneFlights[0];
+    expect(progressedFlight.travel.elapsed).toBeGreaterThan(0);
+
+    const snapshot = serializeStore(store.getState());
+    const savedFlight = snapshot.droneFlights?.[0];
+    expect(savedFlight).toBeDefined();
+
+    const restoredStore = createStoreInstance();
+    restoredStore.getState().applySnapshot(snapshot);
+
+    drone.state = 'idle';
+    drone.targetId = null;
+    drone.travel = null;
+    drone.flightSeed = null;
+    drone.position.copy(world.factory.position);
+
+    const restoredAI = createDroneAISystem(world, restoredStore);
+    restoredAI(0);
+
+    expect(drone.travel).not.toBeNull();
+    expect(drone.state).toBe(savedFlight!.state);
+    expect(drone.flightSeed).toBe(savedFlight!.pathSeed);
+    expect(drone.targetId).toBe(savedFlight!.targetAsteroidId);
+
+    const travelData = drone.travel as TravelData | null;
+    if (!travelData) {
+      throw new Error('expected restored travel data');
+    }
+    const activeTravel = travelData;
+    expect(activeTravel.elapsed).toBeCloseTo(savedFlight!.travel.elapsed, 5);
+
+    const expectedPosition = computeTravelPosition(snapshotToTravel(savedFlight!.travel));
+    expect(drone.position.distanceTo(expectedPosition)).toBeLessThan(1e-4);
+  });
+});

--- a/src/ecs/systems/travel.ts
+++ b/src/ecs/systems/travel.ts
@@ -1,27 +1,62 @@
+import { Vector3 } from 'three';
 import { consumeDroneEnergy } from '@/ecs/energy';
 import type { GameWorld } from '@/ecs/world';
+import { computeTravelPosition, travelToSnapshot } from '@/ecs/flights';
+import { createRng } from '@/lib/rng';
 import { DRONE_ENERGY_COST, type StoreApiType } from '@/state/store';
+
+const offsetVector = new Vector3();
+
+export const computeWaypointWithOffset = (baseWaypoint: Vector3, seed: number, index: number) => {
+  const mixedSeed = (seed ^ ((index + 1) * 0x9e3779b9)) >>> 0;
+  const rng = createRng(mixedSeed || 1);
+  const yaw = rng.nextRange(0, Math.PI * 2);
+  const pitch = rng.nextRange(-Math.PI / 5, Math.PI / 5);
+  const radius = rng.nextRange(0.2, 1);
+  offsetVector.set(
+    Math.cos(yaw) * Math.cos(pitch),
+    Math.sin(pitch),
+    Math.sin(yaw) * Math.cos(pitch),
+  );
+  return baseWaypoint.clone().addScaledVector(offsetVector, radius);
+};
 
 export const createTravelSystem = (world: GameWorld, store: StoreApiType) => {
   const { droneQuery } = world;
   return (dt: number) => {
     if (dt <= 0) return;
-    const throttleFloor = store.getState().settings.throttleFloor;
+    const api = store.getState();
+    const throttleFloor = api.settings.throttleFloor;
     for (const drone of droneQuery) {
       const travel = drone.travel;
       if (!travel) continue;
       const { fraction } = consumeDroneEnergy(drone, dt, throttleFloor, DRONE_ENERGY_COST);
       travel.elapsed = Math.min(travel.elapsed + dt * fraction, travel.duration);
-      const t = travel.duration > 0 ? travel.elapsed / travel.duration : 1;
-      drone.position.lerpVectors(travel.from, travel.to, t);
+      computeTravelPosition(travel, drone.position);
+
+      if (
+        (drone.state === 'toAsteroid' || drone.state === 'returning') &&
+        drone.flightSeed != null
+      ) {
+        api.recordDroneFlight({
+          droneId: drone.id,
+          state: drone.state,
+          targetAsteroidId: drone.state === 'toAsteroid' ? drone.targetId : null,
+          pathSeed: drone.flightSeed,
+          travel: travelToSnapshot(travel),
+        });
+      }
+
       if (travel.elapsed >= travel.duration - 1e-4) {
         drone.position.copy(travel.to);
         drone.travel = null;
+        api.clearDroneFlight(drone.id);
         if (drone.state === 'toAsteroid') {
           drone.state = 'mining';
         } else if (drone.state === 'returning') {
           drone.state = 'unloading';
         }
+        drone.flightSeed = null;
       }
     }
   };

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -11,6 +11,7 @@ export interface TravelData {
   to: Vector3;
   elapsed: number;
   duration: number;
+  control?: Vector3;
 }
 
 export interface FactoryActivityState {
@@ -48,6 +49,7 @@ export interface DroneEntity {
   maxBattery: number;
   charging: boolean;
   lastDockingFrom: Vector3 | null;
+  flightSeed: number | null;
 }
 
 export interface AsteroidEntity {
@@ -148,6 +150,7 @@ const createDrone = (origin: Vector3): DroneEntity => ({
   maxBattery: DEFAULT_DRONE_BATTERY,
   charging: false,
   lastDockingFrom: null,
+  flightSeed: null,
 });
 
 const isDrone = (entity: Entity): entity is DroneEntity => entity.kind === 'drone';

--- a/src/state/import-migrations.test.ts
+++ b/src/state/import-migrations.test.ts
@@ -34,6 +34,7 @@ describe('persistence migration reporting', () => {
   expect(report).toBeTruthy();
   expect(report!.migrated).toBe(true);
   expect(report!.fromVersion).toBe('0.0.1');
+  expect(store.getState().droneFlights).toEqual([]);
   });
 
   it('loadWithReport returns a report after loading a legacy save from storage', () => {
@@ -55,5 +56,6 @@ describe('persistence migration reporting', () => {
   expect(report).toBeTruthy();
   expect(report!.migrated).toBe(true);
   expect(report!.fromVersion).toBe('0.0.1');
+  expect(store.getState().droneFlights).toEqual([]);
   });
 });

--- a/src/state/migrations.test.ts
+++ b/src/state/migrations.test.ts
@@ -21,6 +21,8 @@ describe('migrations', () => {
       expect(migrated.settings).toBeDefined();
       // showTrails should be present and default to true
       expect(migrated.settings.showTrails).toBe(true);
+      expect(Array.isArray(migrated.droneFlights)).toBe(true);
+      expect(migrated.droneFlights?.length).toBe(0);
   });
 
   it('is idempotent when applied to current snapshots', () => {
@@ -29,11 +31,21 @@ describe('migrations', () => {
       modules: { droneBay: 1, refinery: 0, storage: 0, solar: 0, scanner: 0 },
       prestige: { cores: 0 },
       save: { lastSave: Date.now(), version: saveVersion },
-      settings: { autosaveEnabled: true, autosaveInterval: 10, offlineCapHours: 8, notation: 'standard', throttleFloor: 0.25, showTrails: false },
+      settings: {
+        autosaveEnabled: true,
+        autosaveInterval: 10,
+        offlineCapHours: 8,
+        notation: 'standard',
+        throttleFloor: 0.25,
+        showTrails: false,
+        performanceProfile: 'medium',
+      },
+      droneFlights: [] as StoreSnapshot['droneFlights'],
     } as StoreSnapshot;
       const { snapshot: migrated, report } = migrateSnapshot(current);
       expect(report.migrated).toBe(false);
       expect(migrated.save.version).toBe(saveVersion);
       expect(migrated.settings.showTrails).toBe(false);
+      expect(migrated.droneFlights).toEqual([]);
   });
 });

--- a/src/state/migrations.ts
+++ b/src/state/migrations.ts
@@ -26,6 +26,16 @@ const semverCompare = (a: string, b: string) => {
 // Registry of migrations to apply in ascending order of targetVersion
 const migrations: Array<{ targetVersion: string; migrate: MigrationFn }> = [
   {
+    targetVersion: '0.2.0',
+    migrate: (snapshot) => {
+      const migrated = { ...snapshot } as StoreSnapshot;
+      if (!Array.isArray(migrated.droneFlights)) {
+        migrated.droneFlights = [];
+      }
+      return { snapshot: migrated, description: 'initialize drone flight state array' };
+    },
+  },
+  {
     targetVersion: '0.1.0',
     migrate: (snapshot) => {
       const migrated = { ...snapshot } as StoreSnapshot;

--- a/src/state/persistence.test.ts
+++ b/src/state/persistence.test.ts
@@ -24,7 +24,7 @@ describe('state/persistence', () => {
       resources: { ore: 5_000, bars: 0, energy: 160, credits: 0 },
       modules: { droneBay: 3, refinery: 2, storage: 1, solar: 1, scanner: 0 },
       prestige: { cores: 4 },
-      save: { lastSave: FIXED_NOW.getTime() - 13 * 3600 * 1000, version: '0.1.0' },
+      save: { lastSave: FIXED_NOW.getTime() - 13 * 3600 * 1000, version: '0.2.0' },
       settings: {
         autosaveEnabled: true,
         autosaveInterval: 10,
@@ -33,6 +33,7 @@ describe('state/persistence', () => {
         performanceProfile: 'medium' as const,
       },
       rngSeed: 123456789,
+      droneFlights: [],
     };
     window.localStorage.setItem(SAVE_KEY, JSON.stringify(snapshot));
 

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -133,4 +133,28 @@ describe('state/store', () => {
     expect(seededSuccess).toBe(true);
     expect(seededStore.getState().rngSeed).toBe(987654321);
   });
+
+  it('records and clears drone flight snapshots', () => {
+    const store = createStoreInstance();
+    const api = store.getState();
+    api.recordDroneFlight({
+      droneId: 'drone-1',
+      state: 'toAsteroid',
+      targetAsteroidId: 'asteroid-1',
+      pathSeed: 42,
+      travel: {
+        from: [0, 0, 0],
+        to: [10, 0, 0],
+        control: [4, 1, 0],
+        elapsed: 0.25,
+        duration: 1,
+      },
+    });
+    const snapshot = serializeStore(store.getState());
+    expect(snapshot.droneFlights).toHaveLength(1);
+    expect(snapshot.droneFlights?.[0].pathSeed).toBe(42);
+    expect(snapshot.droneFlights?.[0].travel.elapsed).toBeCloseTo(0.25, 5);
+    api.clearDroneFlight('drone-1');
+    expect(store.getState().droneFlights).toHaveLength(0);
+  });
 });

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -1,11 +1,5 @@
 import { expect, test } from '@playwright/test';
 
-const extractValue = (text: string | null) => {
-  if (!text) return 0;
-  const [, value] = text.split(':');
-  return Number.parseFloat(value.trim());
-};
-
 test('app boots and accrues ore', async ({ page }) => {
   page.on('pageerror', (error) => console.error('pageerror:', error));
   page.on('console', (message) => console.log('console:', message.text()));
@@ -13,7 +7,6 @@ test('app boots and accrues ore', async ({ page }) => {
   const hud = page.locator('.hud');
   await expect(hud).toBeVisible({ timeout: 15000 });
   // In headless environments WebGL may not initialize; assert that HUD and Settings are present.
-  const initial = extractValue(await hud.textContent());
-    const upgradeButton = page.getByRole('button', { name: /Prestige Run/i });
-    await expect(upgradeButton).toBeVisible();
+  const upgradeButton = page.getByRole('button', { name: /Prestige Run/i });
+  await expect(upgradeButton).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add `droneFlights` save data with version bump, normalization helpers, and migration coverage
- implement weighted per-drone targeting with seeded bezier travel offsets and README notes
- add targeted unit, integration, and e2e adjustments covering flight persistence and determinism

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f13db0c240832ab03f8c7e91b3f015