### PR TITLE
Implement resource-driven modifiers across systems (DES014)

### DIFF
--- a/memory/activeContext.md
+++ b/memory/activeContext.md
@@ -4,6 +4,8 @@
 
 Implement dynamic asteroid biomes (TASK013): deterministic biome assignment, fracture events, drone reassignment heuristics, and HUD inspector surfacing biome modifiers.
 
+Tie resource types into the live loop (TASK015): implemented modifiers now feed refinery, fleet, power, mining, and HUD; confirm balance and surface follow-up work for consumable effects.
+
 ## Recent Changes
 
 - Finalized spec/persistence backlog items for TASK002, documenting the live manager wiring and Settings defaults.

--- a/memory/designs/DES014-tie-resources.md
+++ b/memory/designs/DES014-tie-resources.md
@@ -2,7 +2,7 @@
 id: DES014
 title: Tie resource types (Metals, Crystals, Organics, Ice) into game loop
 created: 2025-10-17
-updated: 2025-10-17
+updated: 2025-10-18
 authors:
   - copilot
 ---
@@ -60,3 +60,4 @@ Testing
 
 Notes
 - Tuning will require iterating caps/scales based on average resource levels. Add debug UI to surface per-resource M_r values for balancing.
+- 2025-10-18 — Implemented baseline modifiers (caps/scales, helper, ECS integration, HUD debug list). Consumable burst effects remain future work.

--- a/memory/requirements.md
+++ b/memory/requirements.md
@@ -71,3 +71,15 @@ WHEN a drone begins travel, THE SYSTEM SHALL generate a seeded path offset that 
 ## RQ-018 Flight Persistence
 
 WHEN the player saves or reloads while drones are mid-flight, THE SYSTEM SHALL serialize and restore each flight's target, seeded offset, and progress so that drones resume the exact trajectory after load. [Acceptance: Integration test saves a mid-flight snapshot, reloads it, and verifies flight state resumes with matching progress and seed.]
+
+## RQ-019 Resource Modifier Computation
+
+WHEN resource stockpiles change, THE SYSTEM SHALL recompute persistent modifiers using diminishing returns and clamp them to configured caps while exposing the values to downstream systems. [Acceptance: Unit tests cover modifier math for each resource at low/high stocks and assert caps are respected.]
+
+## RQ-020 Resource-Driven Systems Integration
+
+WHEN Metals, Crystals, Organics, or Ice amounts change, THE SYSTEM SHALL adjust drone durability/capacity, refinery yield, and energy storage/generation/consumption within the next simulation tick. [Acceptance: Unit/integration tests observe stat deltas in fleet, refinery, and energy systems after updating the corresponding resources.]
+
+## RQ-021 Resource Modifier Visibility
+
+WHEN players view the HUD, THE SYSTEM SHALL display current resource-derived bonuses with descriptive labels and tooltips that update as resources change. [Acceptance: React component test or manual verification confirms the HUD list reflects live modifier percentages.]

--- a/memory/tasks/TASK015-tie-resources.md
+++ b/memory/tasks/TASK015-tie-resources.md
@@ -1,16 +1,16 @@
 ---
 id: TASK015
 title: Tie resource types into game loop
-status: Pending
+status: Completed
 added: 2025-10-17
-updated: 2025-10-17
+updated: 2025-10-18
 authors:
   - copilot
 ---
 
 # TASK015 — Tie resource types into game loop
 
-**Status:** Pending
+**Status:** Completed
 
 ## Original Request
 
@@ -33,3 +33,5 @@ Add meaningful uses for Metals, Crystals, Organics, and Ice by mapping them to p
 ## Progress Log
 
 2025-10-17 — Created task and linked design DES014.
+2025-10-18 — Reviewing DES014 formulas and planning integration touchpoints for refinery, energy, fleet, and HUD.
+2025-10-18 — Implemented resource modifier config + helper, propagated multipliers through refinery, power, travel, mining, and fleet systems, added HUD debug panel, and expanded test coverage; lint, typecheck, and vitest suites all pass.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -16,4 +16,4 @@
 | TASK012 | Drone Asteroid Targeting Variation      | Completed   | 2025-10-17 |
 | TASK013 | Dynamic Asteroid Biomes Implementation  | In Progress | 2025-10-18 |
 | TASK014 | Dynamic Asteroid Biomes Test Stabilization | Completed   | 2025-10-18 |
-| TASK015 | Tie resource types into game loop       | Pending     | 2025-10-17 |
+| TASK015 | Tie resource types into game loop       | Completed   | 2025-10-18 |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import type { PersistenceManager } from '@/state/persistence';
 import './styles.css';
 import { ToastProvider } from '@/ui/ToastProvider';
 import { AsteroidInspector } from '@/ui/AsteroidInspector';
+import { ResourceModifiersDebug } from '@/ui/ResourceModifiersDebug';
 
 interface AppProps {
   persistence: PersistenceManager;
@@ -33,6 +34,7 @@ export const App = ({ persistence }: AppProps) => {
           <div>Bars: {resources.bars.toFixed(1)}</div>
           <div>Energy: {Math.round(resources.energy)}</div>
           <div>Drones: {modules.droneBay}</div>
+          <ResourceModifiersDebug />
           <button type="button" onClick={() => setSettingsOpen(true)} className="hud-button">
             Settings
           </button>

--- a/src/config/resourceBalance.ts
+++ b/src/config/resourceBalance.ts
@@ -1,0 +1,17 @@
+export interface ResourceBalanceEntry {
+  cap: number;
+  scale: number;
+}
+
+export type BalancedResource = 'metals' | 'crystals' | 'organics' | 'ice';
+
+export const RESOURCE_BALANCE: Record<BalancedResource, ResourceBalanceEntry> = {
+  metals: { cap: 0.3, scale: 10 },
+  crystals: { cap: 0.25, scale: 5 },
+  organics: { cap: 0.4, scale: 8 },
+  ice: { cap: 0.35, scale: 6 },
+};
+
+export const ORGANICS_ENERGY_REGEN_FACTOR = 0.6;
+export const ORGANICS_DRONE_OUTPUT_FACTOR = 1.2;
+export const ICE_DRAIN_REDUCTION_FACTOR = 0.5;

--- a/src/ecs/systems/fleet.test.ts
+++ b/src/ecs/systems/fleet.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { createFleetSystem } from '@/ecs/systems/fleet';
-import { createGameWorld } from '@/ecs/world';
+import {
+  DEFAULT_DRONE_BATTERY,
+  DEFAULT_DRONE_CAPACITY,
+  DEFAULT_DRONE_MINING_RATE,
+  DEFAULT_DRONE_SPEED,
+  createGameWorld,
+} from '@/ecs/world';
 import { createStoreInstance } from '@/state/store';
+import { getResourceModifiers } from '@/lib/resourceModifiers';
 
 describe('ecs/systems/fleet', () => {
   it('maintains drone count according to module level', () => {
@@ -16,5 +23,45 @@ describe('ecs/systems/fleet', () => {
     store.setState((state) => ({ modules: { ...state.modules, droneBay: 2 } }));
     system(0.1);
     expect(world.droneQuery.size).toBe(2);
+  });
+
+  it('applies resource modifiers to drone stats', () => {
+    const world = createGameWorld({ asteroidCount: 0 });
+    const store = createStoreInstance();
+    const system = createFleetSystem(world, store);
+
+    system(0.1);
+    const [drone] = world.droneQuery.entities;
+    if (!drone) throw new Error('expected drone');
+    drone.cargo = 80;
+    drone.cargoProfile.ore = 80;
+
+    store.setState((state) => ({
+      resources: { ...state.resources, metals: 25, organics: 18 },
+    }));
+
+    system(0.1);
+    const state = store.getState();
+    const modifiers = getResourceModifiers(state.resources);
+    const expectedCapacity =
+      (DEFAULT_DRONE_CAPACITY + state.modules.storage * 5) *
+      modifiers.droneCapacityMultiplier;
+
+    expect(drone.capacity).toBeCloseTo(expectedCapacity, 5);
+    expect(drone.cargo).toBeCloseTo(expectedCapacity, 5);
+    expect(drone.cargoProfile.ore).toBeCloseTo(expectedCapacity, 5);
+    expect(drone.miningRate).toBeCloseTo(
+      (DEFAULT_DRONE_MINING_RATE + state.modules.refinery * 0.5) *
+        modifiers.droneProductionSpeedMultiplier,
+      5,
+    );
+    expect(drone.speed).toBeCloseTo(
+      DEFAULT_DRONE_SPEED * modifiers.droneProductionSpeedMultiplier,
+      5,
+    );
+    expect(drone.maxBattery).toBeCloseTo(
+      DEFAULT_DRONE_BATTERY * modifiers.droneBatteryMultiplier,
+      5,
+    );
   });
 });

--- a/src/ecs/systems/mining.test.ts
+++ b/src/ecs/systems/mining.test.ts
@@ -55,4 +55,24 @@ describe('ecs/systems/mining', () => {
 
     expect(drone.cargo).toBe(0);
   });
+
+  it('reduces energy drain when ice modifiers are active', () => {
+    const baseScenario = setupMiningScenario();
+    baseScenario.drone.battery = baseScenario.drone.maxBattery;
+    const baseSystem = createMiningSystem(baseScenario.world, baseScenario.store);
+    baseSystem(1);
+    const baseConsumed = baseScenario.drone.maxBattery - baseScenario.drone.battery;
+
+    const reducedScenario = setupMiningScenario();
+    reducedScenario.drone.battery = reducedScenario.drone.maxBattery;
+    reducedScenario.store.setState((state) => ({
+      resources: { ...state.resources, ice: 40 },
+    }));
+    const reducedSystem = createMiningSystem(reducedScenario.world, reducedScenario.store);
+    reducedSystem(1);
+    const reducedConsumed =
+      reducedScenario.drone.maxBattery - reducedScenario.drone.battery;
+
+    expect(reducedConsumed).toBeLessThan(baseConsumed);
+  });
 });

--- a/src/ecs/systems/power.ts
+++ b/src/ecs/systems/power.ts
@@ -5,14 +5,16 @@ import {
   getEnergyGeneration,
   type StoreApiType,
 } from '@/state/store';
+import { getResourceModifiers } from '@/lib/resourceModifiers';
 
 export const createPowerSystem = (world: GameWorld, store: StoreApiType) => {
   const { droneQuery } = world;
   return (dt: number) => {
     if (dt <= 0) return;
     const state = store.getState();
-    const generation = getEnergyGeneration(state.modules);
-    const cap = getEnergyCapacity(state.modules);
+    const modifiers = getResourceModifiers(state.resources);
+    const generation = getEnergyGeneration(state.modules, modifiers);
+    const cap = getEnergyCapacity(state.modules, modifiers);
     let stored = Math.min(cap, Math.max(0, state.resources.energy + generation * dt));
 
     const chargeRate = DRONE_ENERGY_COST * 2;

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -148,10 +148,10 @@ export const createAsteroid = (scannerLevel: number, rng: RandomSource): Asteroi
   };
 };
 
-const DEFAULT_DRONE_CAPACITY = 40;
-const DEFAULT_DRONE_SPEED = 14;
-const DEFAULT_DRONE_MINING_RATE = 6;
-const DEFAULT_DRONE_BATTERY = 24;
+export const DEFAULT_DRONE_CAPACITY = 40;
+export const DEFAULT_DRONE_SPEED = 14;
+export const DEFAULT_DRONE_MINING_RATE = 6;
+export const DEFAULT_DRONE_BATTERY = 24;
 
 const createDrone = (origin: Vector3): DroneEntity => ({
   id: nextId('drone'),

--- a/src/lib/resourceModifiers.test.ts
+++ b/src/lib/resourceModifiers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { getResourceModifiers } from '@/lib/resourceModifiers';
+
+type ResourcePatch = Partial<{ metals: number; crystals: number; organics: number; ice: number }>;
+
+const buildResources = (patch: ResourcePatch) => ({
+  ore: 0,
+  ice: patch.ice ?? 0,
+  metals: patch.metals ?? 0,
+  crystals: patch.crystals ?? 0,
+  organics: patch.organics ?? 0,
+  bars: 0,
+  energy: 0,
+  credits: 0,
+});
+
+describe('lib/resourceModifiers', () => {
+  it('applies diminishing returns with configured caps', () => {
+    const low = getResourceModifiers(buildResources({ metals: 5, ice: 3, crystals: 2, organics: 4 }));
+    const high = getResourceModifiers(buildResources({ metals: 80, ice: 80, crystals: 80, organics: 80 }));
+
+    expect(low.metalsBonus).toBeGreaterThan(0);
+    expect(low.metalsBonus).toBeLessThan(0.3);
+    expect(high.metalsBonus).toBeCloseTo(0.3, 3);
+    expect(high.crystalsBonus).toBeCloseTo(0.25, 3);
+    expect(high.iceBonus).toBeCloseTo(0.35, 3);
+    expect(high.organicsBonus).toBeCloseTo(0.4, 3);
+  });
+
+  it('derives multipliers from raw bonuses', () => {
+    const modifiers = getResourceModifiers(
+      buildResources({ metals: 12, crystals: 10, organics: 9, ice: 11 }),
+    );
+
+    expect(modifiers.droneCapacityMultiplier).toBeCloseTo(1 + modifiers.metalsBonus, 5);
+    expect(modifiers.droneBatteryMultiplier).toBeCloseTo(1 + modifiers.metalsBonus, 5);
+    expect(modifiers.storageCapacityMultiplier).toBeCloseTo(1 + modifiers.metalsBonus, 5);
+    expect(modifiers.refineryYieldMultiplier).toBeCloseTo(1 + modifiers.crystalsBonus, 5);
+    expect(modifiers.energyStorageMultiplier).toBeCloseTo(1 + modifiers.iceBonus, 5);
+    expect(modifiers.energyDrainMultiplier).toBeLessThan(1);
+    expect(modifiers.energyDrainMultiplier).toBeGreaterThan(0.5);
+    expect(modifiers.droneProductionSpeedMultiplier).toBeGreaterThan(1);
+    expect(modifiers.energyGenerationMultiplier).toBeGreaterThan(1);
+  });
+});

--- a/src/lib/resourceModifiers.ts
+++ b/src/lib/resourceModifiers.ts
@@ -1,0 +1,66 @@
+import { clamp } from '@/lib/math';
+import {
+  ICE_DRAIN_REDUCTION_FACTOR,
+  ORGANICS_DRONE_OUTPUT_FACTOR,
+  ORGANICS_ENERGY_REGEN_FACTOR,
+  RESOURCE_BALANCE,
+  type BalancedResource,
+  type ResourceBalanceEntry,
+} from '@/config/resourceBalance';
+import type { Resources } from '@/state/store';
+
+export interface ResourceModifierSnapshot {
+  metalsBonus: number;
+  crystalsBonus: number;
+  organicsBonus: number;
+  iceBonus: number;
+  droneCapacityMultiplier: number;
+  droneBatteryMultiplier: number;
+  storageCapacityMultiplier: number;
+  refineryYieldMultiplier: number;
+  droneProductionSpeedMultiplier: number;
+  energyGenerationMultiplier: number;
+  energyStorageMultiplier: number;
+  energyDrainMultiplier: number;
+}
+
+const computeBonus = (amount: number, balance: ResourceBalanceEntry) => {
+  const safeAmount = Math.max(0, amount);
+  const scale = balance.scale > 0 ? balance.scale : 1;
+  const bonus = balance.cap * (1 - Math.exp(-safeAmount / scale));
+  return clamp(bonus, 0, balance.cap);
+};
+
+const pickBonus = (resources: Resources, key: BalancedResource) =>
+  computeBonus(resources[key] ?? 0, RESOURCE_BALANCE[key]);
+
+export const getResourceModifiers = (resources: Resources): ResourceModifierSnapshot => {
+  const metalsBonus = pickBonus(resources, 'metals');
+  const crystalsBonus = pickBonus(resources, 'crystals');
+  const organicsBonus = pickBonus(resources, 'organics');
+  const iceBonus = pickBonus(resources, 'ice');
+
+  const droneBatteryMultiplier = 1 + metalsBonus;
+  const droneCapacityMultiplier = 1 + metalsBonus;
+  const storageCapacityMultiplier = 1 + metalsBonus;
+  const refineryYieldMultiplier = 1 + crystalsBonus;
+  const droneProductionSpeedMultiplier = 1 + ORGANICS_DRONE_OUTPUT_FACTOR * organicsBonus;
+  const energyGenerationMultiplier = 1 + ORGANICS_ENERGY_REGEN_FACTOR * organicsBonus;
+  const energyStorageMultiplier = 1 + iceBonus;
+  const energyDrainMultiplier = clamp(1 - ICE_DRAIN_REDUCTION_FACTOR * iceBonus, 0.5, 1);
+
+  return {
+    metalsBonus,
+    crystalsBonus,
+    organicsBonus,
+    iceBonus,
+    droneCapacityMultiplier,
+    droneBatteryMultiplier,
+    storageCapacityMultiplier,
+    refineryYieldMultiplier,
+    droneProductionSpeedMultiplier,
+    energyGenerationMultiplier,
+    energyStorageMultiplier,
+    energyDrainMultiplier,
+  };
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -46,6 +46,54 @@ canvas {
   justify-self: start;
 }
 
+.hud-modifiers {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(15, 118, 110, 0.08);
+  border: 1px solid rgba(45, 212, 191, 0.2);
+  width: min(260px, 100%);
+}
+
+.hud-modifiers h4 {
+  margin: 0 0 0.4rem;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(165, 243, 252, 0.9);
+}
+
+.hud-modifiers-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.hud-modifiers-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.82rem;
+  gap: 0.75rem;
+}
+
+.hud-modifiers-item:hover {
+  color: #f0fdf4;
+}
+
+.hud-modifiers-label {
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.hud-modifiers-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: rgba(45, 212, 191, 0.95);
+}
+
 .panel {
   position: absolute;
   top: 1rem;

--- a/src/ui/ResourceModifiersDebug.tsx
+++ b/src/ui/ResourceModifiersDebug.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from 'react';
+import { useStore } from '@/state/store';
+import { getResourceModifiers } from '@/lib/resourceModifiers';
+
+const formatPercent = (value: number) => {
+  const rounded = Math.round(value * 1000) / 10;
+  if (Math.abs(rounded) < 0.05) {
+    return '0.0%';
+  }
+  return `${rounded.toFixed(1)}%`;
+};
+
+const formatDelta = (delta: number) => {
+  const rounded = Math.round(delta * 1000) / 10;
+  if (Math.abs(rounded) < 0.05) {
+    return '0.0%';
+  }
+  const sign = rounded > 0 ? '+' : '−';
+  return `${sign}${Math.abs(rounded).toFixed(1)}%`;
+};
+
+export const ResourceModifiersDebug = () => {
+  const resources = useStore((state) => state.resources);
+  const modifiers = useMemo(() => getResourceModifiers(resources), [resources]);
+
+  const entries = [
+    {
+      label: 'Drone Capacity',
+      delta: modifiers.droneCapacityMultiplier - 1,
+      tooltip: `Metals bonus ${formatPercent(modifiers.metalsBonus)} boosts cargo pods.`,
+    },
+    {
+      label: 'Drone Battery',
+      delta: modifiers.droneBatteryMultiplier - 1,
+      tooltip: `Metals bonus ${formatPercent(modifiers.metalsBonus)} reinforces chassis.`,
+    },
+    {
+      label: 'Refinery Yield',
+      delta: modifiers.refineryYieldMultiplier - 1,
+      tooltip: `Crystals bonus ${formatPercent(modifiers.crystalsBonus)} tunes refinement.`,
+    },
+    {
+      label: 'Drone Output Speed',
+      delta: modifiers.droneProductionSpeedMultiplier - 1,
+      tooltip: `Organics bonus ${formatPercent(modifiers.organicsBonus)} accelerates fabrication.`,
+    },
+    {
+      label: 'Energy Storage',
+      delta: modifiers.energyStorageMultiplier - 1,
+      tooltip: `Ice bonus ${formatPercent(modifiers.iceBonus)} expands capacitor banks.`,
+    },
+    {
+      label: 'Energy Generation',
+      delta: modifiers.energyGenerationMultiplier - 1,
+      tooltip: `Organics bonus ${formatPercent(modifiers.organicsBonus)} boosts passive regen.`,
+    },
+    {
+      label: 'Energy Drain',
+      delta: modifiers.energyDrainMultiplier - 1,
+      tooltip: `Ice bonus ${formatPercent(modifiers.iceBonus)} cools systems to reduce drain.`,
+    },
+  ];
+
+  return (
+    <div className="hud-modifiers" aria-live="polite">
+      <h4>Resource Bonuses</h4>
+      <ul className="hud-modifiers-list">
+        {entries.map((entry) => (
+          <li key={entry.label} className="hud-modifiers-item" title={entry.tooltip}>
+            <span className="hud-modifiers-label">{entry.label}</span>
+            <span className="hud-modifiers-value">{formatDelta(entry.delta)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add resource balance configuration and helper to compute diminishing-return modifiers
- pipe Metals/Crystals/Organics/Ice multipliers into fleet, refinery, energy, travel/mining, and HUD debug display
- extend unit/integration coverage plus memory updates for TASK015/DES014 completion

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f184589628832a855e410f515fa683